### PR TITLE
neutrino.js.org

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -767,7 +767,7 @@ var cnames_active = {
   "nemaniarjun": "nemaniarjun.github.io",
   "nemo": "paypal.github.io/nemo", // noCF? (don´t add this in a new PR)
   "neo4": "janpeter.github.io/neo4js",
-  "neutrino": "mozilla-neutrino.github.io/neutrino-dev",
+  "neutrino": "neutrinojs.netlify.com", // noCF
   "nflow": "nflow-js.github.io", // noCF? (don´t add this in a new PR)
   "ng-dux": "mister-what.github.io/ngDux",
   "ng-wig": "stevermeister.github.io/ngWig", // noCF? (don´t add this in a new PR)


### PR DESCRIPTION
Since we're switching from GitHub pages to Netlify, for all the auto-deployment and PR preview goodness.

See:
https://github.com/mozilla-neutrino/neutrino-dev/pull/891

- [x] There is reasonable content on the page (see: [No Content](https://github.com/js-org/js.org/wiki/No-Content))
- [x] I have read and accepted the [Terms and Conditions](http://js.org/terms.html)

cc @eliperelman 