### PR TITLE
miscord.js.org

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -735,7 +735,7 @@ var cnames_active = {
   "mininote": "htdt.github.io/mininote",
   "miny": "pablopunk.github.io/miny",
   "mis101bird": "mis101bird.github.io", // noCF? (don´t add this in a new PR)
-  "miscord": "bjornskjald.github.io/miscord",
+  "miscord": "bjornskjald.github.io/miscord-website-redirect",
   "mithril-ja": "shibukawa.github.io/mithril-ja", // noCF? (don´t add this in a new PR)
   "mithril": "mithriljs.github.io/mithril.js",
   "mmcq": "nikola.github.io/MMCQ", // noCF? (don´t add this in a new PR)


### PR DESCRIPTION
- There is reasonable content on the page (see: [No Content](https://github.com/js-org/js.org/wiki/No-Content))
- I have read and accepted the [Terms and Conditions](http://js.org/terms.html)

As I've bought a regular domain for my project, I'd like to redirect users visiting miscord.js.org to miscord.net, but I couldn't find a better way to do this
