### PR TITLE
purpziesucks.js.org / purpzie.js.org

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -976,8 +976,7 @@ var cnames_active = {
   "protype": "arguiot.github.io/ProType",
   "pure": "fengzilong.github.io/pure",
   "prylaris": "prylaris.github.io",
-  "purpzie": "purpzie.github.io",
-  "purpziesucks": "purpzie.github.io/sucks",
+  "purpzie": "purpzie.github.io/site",
   "pwa-cookbook": "sylvainpolletvillard.github.io/pwa-cookbook",
   "pwa-workshop": "sylvainpolletvillard.github.io/pwa-workshop",
   "qs": "kirjs.github.io/qs.js", // noCF? (don´t add this in a new PR)


### PR DESCRIPTION
Moved purpzie.github.io to purpzie.github.io/site. Because purpzie.github.io redirects to purpzie.js.org right now, it won't show https://github.com/purpzie/site but you can still check the files, they have content.
I was the one who put these in originally (https://github.com/js-org/js.org/pull/1970)

- There is reasonable content on the page (see: [No Content](https://github.com/js-org/js.org/wiki/No-Content))
- I have read and accepted the [Terms and Conditions](http://js.org/terms.html)
