### PR TITLE
c-3po.js.org

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -200,7 +200,7 @@ var cnames_active = {
   "burst": "hugeen.github.io/burst", // noCF? (don´t add this in a new PR)
   "bustime": "agarzola.github.io/bustime", // noCF? (don´t add this in a new PR)
   "buttermilk": "buttermilk.netlify.com",
-  "c-3po": "c-3po-org.github.io/c-3po",
+  "c-3po": "https://ttag-org.github.io/c-3po",
   "cable": "whatgoodisaroad.github.io/cablejs", // noCF? (don´t add this in a new PR)
   "cac": "cac.netlify.com",
   "caffeine": "ccrraaiigg.github.io/caffeine",
@@ -1302,6 +1302,7 @@ var cnames_active = {
   "ts2jsdoc": "spatools.github.io/ts2jsdoc", // noCF? (don´t add this in a new PR)
   "tsdi": "knisterpeter.github.io/tsdi",
   "tsfp": "zhenwenc.github.io/tsfp", // noCF? (don´t add this in a new PR)
+  "ttag": "https://ttag-org.github.io/ttag",
   "ttgprotect": "ttgprotect.github.io",
   "turbo": "turbo.github.io",
   "tux": "tux.gitbooks.io/docs",

--- a/cnames_active.js
+++ b/cnames_active.js
@@ -200,7 +200,7 @@ var cnames_active = {
   "burst": "hugeen.github.io/burst", // noCF? (don´t add this in a new PR)
   "bustime": "agarzola.github.io/bustime", // noCF? (don´t add this in a new PR)
   "buttermilk": "buttermilk.netlify.com",
-  "c-3po": "https://ttag-org.github.io/c-3po",
+  "c-3po": "ttag-org.github.io/c-3po",
   "cable": "whatgoodisaroad.github.io/cablejs", // noCF? (don´t add this in a new PR)
   "cac": "cac.netlify.com",
   "caffeine": "ccrraaiigg.github.io/caffeine",
@@ -1302,7 +1302,7 @@ var cnames_active = {
   "ts2jsdoc": "spatools.github.io/ts2jsdoc", // noCF? (don´t add this in a new PR)
   "tsdi": "knisterpeter.github.io/tsdi",
   "tsfp": "zhenwenc.github.io/tsfp", // noCF? (don´t add this in a new PR)
-  "ttag": "https://ttag-org.github.io/ttag",
+  "ttag": "ttag-org.github.io/ttag",
   "ttgprotect": "ttgprotect.github.io",
   "turbo": "turbo.github.io",
   "tux": "tux.gitbooks.io/docs",


### PR DESCRIPTION
Due to this issue https://github.com/ttag-org/ttag/issues/105 we decided to rename our library from `c-3po` to `ttag`. We still want to keep old links to c-3po.js.org alive.

So a couple of things are going on here:

1. Changing current c-3po.js.org location
2. Adding a new domain name for ttag.js.org

Thanks for understanding, sorry for the extra work with the same domain

- There is reasonable content on the page (see: [No Content](https://github.com/js-org/js.org/wiki/No-Content))
- I have read and accepted the [Terms and Conditions](http://js.org/terms.html)
