### PR TITLE
sshplendid.js.org

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -1239,6 +1239,7 @@ var cnames_active = {
   "squeak": "bertfreudenberg.github.io/SqueakJS",
   "squirrelly": "nebrelbug.github.io/squirrelly-website",
   "sri": "jackub.github.io/subresource-integrity-fallback",
+  "sshplendid": "sshplendid.github.io/sshplendid.js.org",
   "stabs": "wnda.github.io/stabs",
   "stack": "stackgamedevelopment.github.io",
   "stahlstadt": "dist1.storyblok.com",


### PR DESCRIPTION
add an url sshplendid.js.org

- There is reasonable content on the page (see: [No Content](https://github.com/js-org/js.org/wiki/No-Content))
- I have read and accepted the [Terms and Conditions](http://js.org/terms.html)
