### PR TITLE
silkster.js.org

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -1198,6 +1198,7 @@ var cnames_active = {
   "shortquery": "s--minecraft.gitbooks.io/shortquery-js", // noCF? (don´t add this in a new PR)
   "shscode":"shs-coding-club-projects.github.io",
   "silfr": "silfr.github.io/iterativecolor",
+  "silkster": "silkster.github.io",
   "silky": "wvv8oo.github.com/silky", // noCF? (don´t add this in a new PR)
   "siluna": "pahund.github.io/siluna", // noCF? (don´t add this in a new PR)
   "simulacra": "daliwali.github.io/simulacra",


### PR DESCRIPTION
Map silkster.github.io to silkster.js.org

- There is reasonable content on the page (see: [No Content](https://github.com/js-org/js.org/wiki/No-Content))
- I have read and accepted the [Terms and Conditions](http://js.org/terms.html)

The page is a work-in-progress. I'm getting it set up as a JS blog site now.