### PR TITLE
Moving react-observatory to hosting.gitbook.com

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -1084,7 +1084,7 @@ var cnames_active = {
   "react-leaflet": "paullecam.github.io/react-leaflet",
   "react-move": "react-move.netlify.com",
   "react-native-floating-labels": "mayank-patel.github.io/react-native-floating-labels",
-  "react-observatory": "halfzebra.gitbooks.io/react-observatory",
+  "react-observatory": "hosting.gitbook.com",
   "react-pivottable": "plotly.github.io/react-pivottable",
   "react-responsive-carousel": "leandrowd.github.io/react-responsive-carousel", // noCF? (don´t add this in a new PR)
   "react-shared": "rvikmanis.github.io/react-shared", // noCF? (don´t add this in a new PR)


### PR DESCRIPTION
Thanks for doing this! 👍 

I'm merely changing the address for the docs.

- There is reasonable content on the page (see: [No Content](https://github.com/js-org/js.org/wiki/No-Content))
- I have read and accepted the [Terms and Conditions](http://js.org/terms.html)
