### PR TITLE
react-redux.js.org

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -1094,6 +1094,7 @@ var cnames_active = {
   "react-native-floating-labels": "mayank-patel.github.io/react-native-floating-labels",
   "react-observatory": "hosting.gitbook.com",
   "react-pivottable": "plotly.github.io/react-pivottable",
+  "react-redux": "react-redux-docs.netlify.com"
   "react-responsive-carousel": "leandrowd.github.io/react-responsive-carousel", // noCF? (don´t add this in a new PR)
   "react-shared": "rvikmanis.github.io/react-shared", // noCF? (don´t add this in a new PR)
   "react-state": "tannerlinsley.github.io/react-state",


### PR DESCRIPTION
Currently working on setting up docs publishing for React-Redux, per https://github.com/reduxjs/react-redux/issues/1031 .

Site is hosted at https://react-redux-docs.netlify.com/ .  Semi-placeholder content for now (just the one page).  We'll start publishing things for real as soon as we can figure out which site gen tool we're using.

CNAME has been added at https://github.com/reduxjs/react-redux/blob/master/CNAME , and we're good with the terms and conditions.

- There is reasonable content on the page (see: [No Content](https://github.com/js-org/js.org/wiki/No-Content))
- I have read and accepted the [Terms and Conditions](http://js.org/terms.html)
