### PR TITLE
wiki.js.org

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -1506,7 +1506,7 @@ var cnames_active = {
   "weekly": "xdimh.github.io/weekly",
   "whiteboard": "yhozen.github.io/whiteboard",
   "wice": "yulioaj290.github.io/wice.js",
-  "wiki": "requarks.github.io/wiki-site",
+  "wiki": "wikijs.netlify.com", // noCF
   "wildfire": "cheng-kang.github.io/wildfire",
   "within": "eric-brechemier.github.io/within", // noCF? (don´t add this in a new PR)
   "wooyun": "jiji262.github.io/wooyun_articles",


### PR DESCRIPTION
- [x] There is reasonable content on the page (see: [No Content](https://github.com/js-org/js.org/wiki/No-Content))
- [x] I have read and accepted the [Terms and Conditions](http://js.org/terms.html)

This is a CNAME update for existing entry wiki.js.org, which moved from GitHub Pages to Netlify.

Can the CloudFlare proxy be deactivated for this entry? Netlify provides the SSL certificate and global CDN so it would be a bit redundant to have 2 proxies on top of each other.

Thanks!
Nick