### PR TITLE
remove mysite.js.org per #2448

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -892,7 +892,6 @@ var cnames_active = {
   "mvidalgarcia": "mvidalgarcia.github.io", // noCF? (don´t add this in a new PR)
   "mw": "agauniyal.github.io/mw",
   "mysketch": "dipanshkhandelwal.github.io/MySketch",
-  "mysite": "archiebaer.github.io/mysite-js",
   "mythbusters": "mythbustersjs.netlify.com",
   "n-j-m": "n-j-m.github.io", // noCF? (don´t add this in a new PR)
   "namelessman": "namelessman.github.io",


### PR DESCRIPTION
Per #2448 it is implied this user is no longer welcome to subdomains, this one was still present. Will it be removed or kept?