### PR TITLE
hybrids.js.org

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -598,6 +598,7 @@ var cnames_active = {
   "human": "human-js.gitbooks.io", // noCF? (don´t add this in a new PR)
   "hx": "hifocus.github.io/www.hxis.me",
   "hxxbit": "hxxbit.github.io",
+  "hybrids": "hosting.gitbook.com", // noCF
   "hyde": "gheek.github.io/hyde", // noCF? (don´t add this in a new PR)
   "hyf": "yafey.github.io",
   "hyperapp": "hyperapp.github.io",


### PR DESCRIPTION
I would like to add [hybrids](https://github.com/hybridsjs/hybrids) library documentation site: https://hybrids.gitbook.io/hybrids.

- [x] There is reasonable content on the page (see: [No Content](https://github.com/js-org/js.org/wiki/No-Content))
- [x] I have read and accepted the [Terms and Conditions](http://js.org/terms.html)
