### PR TITLE
Adds react-dropzone-uploader subdomain

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -1125,6 +1125,7 @@ var cnames_active = {
   "react-coroutine": "alexeyraspopov.github.io/react-coroutine",
   "react-day-picker": "gpbl.github.io/react-day-picker", // noCF
   "react-dropzone": "react-dropzone.netlify.com",
+  "react-dropzone-uploader": "fortana-co.github.io/react-dropzone-uploader",
   "react-easy-swipe": "leandrowd.github.io/react-easy-swipe", // noCF? (don´t add this in a new PR)
   "react-entanglement": "react-entanglement.github.io",
   "react-form": "react-form.netlify.com",


### PR DESCRIPTION
I'd like <https://fortana-co.github.io/react-dropzone-uploader> to point to <https://react-dropzone-uploader.js.org>.

I've added a CNAME file here to prove I own the repo.

I added it to `master` instead of `gh-pages`, because if I add it to the `gh-pages` branch GitHub redirects all petitions from <https://fortana-co.github.io/react-dropzone-uploader> to <https://react-dropzone-uploader.js.org>, which can't respond to requests yet.


- [X] There is reasonable content on the page (see: [No Content](https://github.com/js-org/js.org/wiki/No-Content))
- [X] I have read and accepted the [Terms and Conditions](http://js.org/terms.html)
