### PR TITLE
birb.js.org

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -175,6 +175,7 @@ var cnames_active = {
   "brotat": "mariobob.github.io/brotat-website",
   "bildepunkt": "bildepunkt.github.io", // noCF? (don´t add this in a new PR)
   "bind-action-dispatchers": "cchamberlain.github.io/bind-action-dispatchers", // noCF? (don´t add this in a new PR)
+  "birb": "purpzie.github.io/birb.js.org",
   "biu": "aprilorange.github.io/biu", // noCF? (don´t add this in a new PR)
   "bfd": "mrsheldon.github.io/bfd.js",
   "blessmyrains": "dusterthefirst.github.io/blessmyrains",


### PR DESCRIPTION
Still has the post examples from the jekyll template, but I'll fix that later. 👍

- [x] There is reasonable content on the page (see: [No Content](https://github.com/js-org/js.org/wiki/No-Content))
- [x] I have read and accepted the [Terms and Conditions](http://js.org/terms.html)
