### PR TITLE
spasock.js.org

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -1228,7 +1228,7 @@ var cnames_active = {
   "sox": "sox-team.github.io/sox", // noCF? (don´t add this in a new PR)
   "spa": "sucom.github.io/SPA.js",
   "spaas": "pakastin.github.io/spaas",
-  "spasock": "http://spasock.github.io/website",
+  "spasock": "http://spasock.github.io",
   "spectragram": "adrianengine.github.io/jquery-spectragram", // noCF? (don´t add this in a new PR)
   "spike": "spike.netlify.com",
   "spin": "fgnass.github.io/spin.js", // noCF? (don´t add this in a new PR)

--- a/cnames_active.js
+++ b/cnames_active.js
@@ -1228,6 +1228,7 @@ var cnames_active = {
   "sox": "sox-team.github.io/sox", // noCF? (don´t add this in a new PR)
   "spa": "sucom.github.io/SPA.js",
   "spaas": "pakastin.github.io/spaas",
+  "spasock": "http://spasock.github.io/base",
   "spectragram": "adrianengine.github.io/jquery-spectragram", // noCF? (don´t add this in a new PR)
   "spike": "spike.netlify.com",
   "spin": "fgnass.github.io/spin.js", // noCF? (don´t add this in a new PR)

--- a/cnames_active.js
+++ b/cnames_active.js
@@ -1228,7 +1228,7 @@ var cnames_active = {
   "sox": "sox-team.github.io/sox", // noCF? (don´t add this in a new PR)
   "spa": "sucom.github.io/SPA.js",
   "spaas": "pakastin.github.io/spaas",
-  "spasock": "http://spasock.github.io",
+  "spasock": "spasock.github.io",
   "spectragram": "adrianengine.github.io/jquery-spectragram", // noCF? (don´t add this in a new PR)
   "spike": "spike.netlify.com",
   "spin": "fgnass.github.io/spin.js", // noCF? (don´t add this in a new PR)

--- a/cnames_active.js
+++ b/cnames_active.js
@@ -1228,7 +1228,7 @@ var cnames_active = {
   "sox": "sox-team.github.io/sox", // noCF? (don´t add this in a new PR)
   "spa": "sucom.github.io/SPA.js",
   "spaas": "pakastin.github.io/spaas",
-  "spasock": "http://spasock.github.io/base",
+  "spasock": "http://spasock.github.io/website",
   "spectragram": "adrianengine.github.io/jquery-spectragram", // noCF? (don´t add this in a new PR)
   "spike": "spike.netlify.com",
   "spin": "fgnass.github.io/spin.js", // noCF? (don´t add this in a new PR)


### PR DESCRIPTION
Adds a spasock domain for http://spasock.github.io, spasock.js.org

- [x] There is reasonable content on the page (see: [No Content](https://github.com/js-org/js.org/wiki/No-Content)) (the content can not be viewed right now because it attempts to redirect to spasock.js.org
- [x] I have read and accepted the [Terms and Conditions](http://js.org/terms.html)
