### PR TITLE
New Site link for YAJDBL

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -1481,7 +1481,7 @@ var cnames_active = {
   "y86": "quietshu.github.io/y86", // noCF? (don´t add this in a new PR)
   "yadl": "yadljs.github.io",
   "yagolopez": "yagolopez.github.io",
-  "yajdbl": "pixelthegreat.github.io/YAJDBL",
+  "yajdbl": "yajdbl.github.io/yajdbl/",
   "yamdbf": "zajrik.github.io/yamdbf",
   "yamil-villarreal": "yvillarreal.github.io/index",
   "yargs": "yargs.github.io", // noCF? (don´t add this in a new PR)


### PR DESCRIPTION
- [x] There is reasonable content on the page (see: [No Content](https://github.com/js-org/js.org/wiki/No-Content))
- [x] I have read and accepted the [Terms and Conditions](http://js.org/terms.html)


I changed the link for the yajdbl docs ( mine ) since the old github.io link is gone