### PR TITLE
redux.js.org

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -1130,7 +1130,7 @@ var cnames_active = {
   "redux-tiles": "bloomca.github.io/redux-tiles",
   "redux-undo": "omnidan.github.io/redux-undo", // noCF? (don´t add this in a new PR)
   "redux-webpack-boilerplate": "cchamberlain.github.io/redux-webpack-boilerplate", // noCF? (don´t add this in a new PR)
-  "redux": "hosting.gitbook.com", // noCF
+  "redux": "redux-docs.netlify.com", // noCF
   "reduxible": "pitzcarraldo.github.io/reduxible", // noCF? (don´t add this in a new PR)
   "refract": "hosting.gitbook.com",
   "refraction": "mbasso.github.io/refraction", // noCF? (don´t add this in a new PR)


### PR DESCRIPTION
- [x] There is reasonable content on the page (see: [No Content](https://github.com/js-org/js.org/wiki/No-Content))
- [x] I have read and accepted the [Terms and Conditions](http://js.org/terms.html)

**Note: Do not merge yet**

We're getting ready to switch the Redux docs hosting from Gitbook to Netlify.  The new site is currently live at https://redux-docs.netlify.com .  

Per https://github.com/reduxjs/redux/issues/3161#issuecomment-445658858 , we've got a couple more tweaks we want to do before flipping the switch, but I wanted to get the PR filed so that we can coordinate on timing.

Thanks!