### PR TITLE
Use new repo location

### DIFF
--- a/404.html
+++ b/404.html
@@ -52,7 +52,7 @@
                 </a>
             </td>
             <td>
-                <a class="gh" title="GitHub" rel="nofollow" target="_blank" href="https://github.com/js-org/dns.js.org">&#xe613;
+                <a class="gh" title="GitHub" rel="nofollow" target="_blank" href="https://github.com/js-org/js.org.js.org">&#xe613;
                     <span id="ghstars" style="display: inline-block;"></span>
                 </a>
             </td>

--- a/index.html
+++ b/index.html
@@ -59,7 +59,7 @@
             <h3>2</h3>Now you should determine your js.org subdomain: either choose your username or the name of your repo according
             to the existing GitHub Pages URL (for http://foo.github.io/bar, either "foo.js.org" or "bar.js.org" would be
             possible). More details in the
-            <a title="JS.ORG's Wiki" rel="nofollow noreferrer noopener" target="_blank" href="https://github.com/js-org/dns/wiki" >wiki</a>.
+            <a title="JS.ORG's Wiki" rel="nofollow noreferrer noopener" target="_blank" href="https://github.com/js-org/js.org/wiki" >wiki</a>.
         </article>
         <input id="s3I" name="step" type="radio">
         <article>
@@ -71,7 +71,7 @@
         <input id="s4I" name="step" type="radio">
         <article>
             <h3>4</h3>To finish the procedure, make a pull request in our GitHub
-            <a title="JS.ORGs repository" rel="nofollow noreferrer noopener" href="https://github.com/js-org/dns/tree/master" target="_blank">repository</a> that adds your subdomain to the list of existing JS.ORG domains. Your new URL should go live within
+            <a title="JS.ORGs repository" rel="nofollow noreferrer noopener" href="https://github.com/js-org/js.org/tree/master" target="_blank">repository</a> that adds your subdomain to the list of existing JS.ORG domains. Your new URL should go live within
             24 hours (keep an eye on your pull request in case of a naming conflict or a question from our side).
         </article>
         <nav>


### PR DESCRIPTION
Use new repo location for links in gh-pages instead of relying on redirect from old repo location