### PR TITLE
macosnotif.js.org

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -781,7 +781,7 @@ var cnames_active = {
   "lyra": "amansahil.github.io/lyra.js.org",
   "m8bot": "mapreiff.github.io/m8-bot-site",
   "ma124": "ma124.netlify.com",
-  "macosnotif": "macosnotifjs.mattcowley.co.uk", // noCF
+  "macosnotif": "merlin.servers.unreal-designs.co.uk",
   "madankumar": "jmadankumar.github.io",
   "magnet": "magnetjs.github.io/Magnet", // noCF? (don´t add this in a new PR)
   "mahdyar": "mahdyar.github.io/mahdyar.js.org",


### PR DESCRIPTION
Update CNAME for macosnotif.js.org and enable CF
Resolves #2672 

- [x] There is reasonable content on the page (see: [No Content](https://github.com/js-org/js.org/wiki/No-Content))
- [x] I have read and accepted the [Terms and Conditions](http://js.org/terms.html)
