### PR TITLE
next.js.org

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -926,6 +926,7 @@ var cnames_active = {
   "netology-group": "netology-group.github.io",
   "neutralino": "neutralinojs.github.io",
   "neutrino": "neutrinojs.netlify.com", // noCF
+  "next": "zeit.github.io/next-site",
   "nflow": "nflow-js.github.io", // noCF? (don´t add this in a new PR)
   "nfwyst": "nfwyst.github.io",
   "ng-app": "zackschuster.github.io/ng-app",


### PR DESCRIPTION
This PR adds `next.js.org` for [Next.js](https://github.com/zeit/next.js), pointing to zeit.github.io/next-site (which redirects to [nextjs.org](https://nextjs.org)).

- [x] There is reasonable content on the page (see: [No Content](https://github.com/js-org/js.org/wiki/No-Content))
- [x] I have read and accepted the [Terms and Conditions](http://js.org/terms.html)