### PR TITLE
cml.js.org

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -277,6 +277,7 @@ var cnames_active = {
   "clusterize": "nexts.github.io/Clusterize.js",
   "cmbhackjs2013": "cmbjs.github.io/cmbHackjs2013",
   "cmdhub": "thatonetqnk.github.io/cmdhub",
+  "cml": "didi.github.io/chameleon",
   "cn.iflow": "unadlib.github.io/iflow-docs-cn",
   "cn.mobx": "sangka.github.io/mobx-docs-cn", // noCF
   "cn.redux": "camsong.github.io/redux-in-chinese", // noCF? (don´t add this in a new PR)


### PR DESCRIPTION
add cml.js.org
That browse didi.github.io/chameleon redirect to error page if i add the CNAME before add the subdomain. Since that didi.github.io/chameleon had user visits. Please.

- [x] There is reasonable content on the page (see: [No Content](https://github.com/js-org/js.org/wiki/No-Content))
- [x] I have read and accepted the [Terms and Conditions](http://js.org/terms.html)
