### PR TITLE
gh.js.org

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -558,6 +558,7 @@ var cnames_active = {
   "german": "dipanshkhandelwal.github.io/Learning-German",
   "get": "hxco.github.io/Get",
   "getlink": "ilovecode1.github.io/linkjs", // noCF? (don´t add this in a new PR)
+  "gh": "req-res.github.io/ghwidget",
   "ghastly": "hkwu.github.io/ghastly",
   "ghapi": "haydennyyy.github.io/ghapi-website",
   "ghsamm": "ghsamm.github.io", // noCF? (don´t add this in a new PR)


### PR DESCRIPTION
- [x] There is reasonable content on the page (see: [No Content](https://github.com/js-org/js.org/wiki/No-Content))
- [x] I have read and accepted the [Terms and Conditions](http://js.org/terms.html)

I have create a widget in JavaScript for Github Profiles that uses the Github API. Currently, the URL is a bit long:
![image](https://user-images.githubusercontent.com/47814909/53200058-8f221000-3618-11e9-807c-594f28559fb6.png)

So I was hoping I could use `gh.js.org#USERNAME`. You would use an iframe to embed it on a website. I've added the CNAME to the github repo.