### PR TITLE
countr.js.org

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -323,6 +323,7 @@ var cnames_active = {
   "corki": "dvtate.github.io/corki",
   "corps": "copay.github.io",
   "cote": "dashersw.github.io/cote", // noCF? (don´t add this in a new PR)
+  "countr": "gleeny.github.io/countr",
   "country": "growmies.github.io/countryjs", // noCF? (don´t add this in a new PR)
   "cp": "nestedobjects.github.io/cp",
   "cplayer": "copay.github.io/cPlayer",


### PR DESCRIPTION
- [x] There is reasonable content on the page (see: [No Content](https://github.com/js-org/js.org/wiki/No-Content))
- [x] I have read and accepted the [Terms and Conditions](http://js.org/terms.html)

Since my main website (promise.js.org) is registered on js.org, gleeny.github.io/countr gets redirected to promise.js.org/countr. I don't know if this is an issue or not, so just wanted to let you know. If it's an issue, i can just remove the main website in the future.

Also, I have not added `CNAME` to the repository yet, since the website has a lot of traffic coming through promise.js.org/countr. I would like to keep the website functioning until I get (if I get it) countr.js.org.

Thanks in advance.