### PR TITLE
jsxcad.js.org

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -726,6 +726,7 @@ var cnames_active = {
   "jsonapi": "ethanresnick.github.io/json-api",
   "jsonui": "yourtion.github.io/vue-json-ui-editor",
   "jsonuri": "aligay.github.io/jsonuri",
+  "jsxcad": "jsxcad.github.io",
   "juancarlosqr": "juancarlosqr.github.io", // noCF? (don´t add this in a new PR)
   "julien": "julien.github.io", // noCF? (don´t add this in a new PR)
   "junctions": "jamesknelson.github.io/junctions",


### PR DESCRIPTION
- [o] There is reasonable content on the page (see: [No Content](https://github.com/js-org/js.org/wiki/No-Content))

At least in theory.

I may have done something weird with CNAME since it is redirecting to jsxcad.js.org and I can't see it at the moment.

- [o] I have read and accepted the [Terms and Conditions](http://js.org/terms.html)

I have read them, considered them acceptable, and accepted them.