### PR TITLE
div.js.org

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -347,6 +347,7 @@ var cnames_active = {
   "distillery": "achannarasappa.github.io/distillery", // noCF? (don´t add this in a new PR)
   "distri": "flarp.github.io/Distri.js",
   "distribution": "distributionjs.github.io/website",
+  "div": "div-js.github.io",
   "djsbasics": "djsbasics.gitlab.io/mkdocs",
   "djvu": "russcoder.github.io/djvujs",
   "djzhao": "djzhao627.github.io",


### PR DESCRIPTION
I've reserved the "div" name on npm and "div-js" on github for my open-source node.js project, long time ago.
But there were no time to continue it. Therefore, I left it empty.
Now, I wanna implement my ideas on it and I feel we need a js.org subdomain to start.

( I'm that person who registered the "imrc-datetime-picker" subdomain. )

Thanks

- [x] There is reasonable content on the page (see: [No Content](https://github.com/js-org/js.org/wiki/No-Content))
- [x] I have read and accepted the [Terms and Conditions](http://js.org/terms.html)
