### PR TITLE
vuelidate.js.org

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -1597,6 +1597,7 @@ var cnames_active = {
   "vue-treeselect": "riophae.github.io/vue-treeselect",
   "vuejsindy": "vuejsindy.github.io",
   "vuelog": "myst729.github.io/Vuelog",
+  "vuelidate": "vuelidate.netlify.com",
   "vuetify-sidebar-template": "disjfa.github.io/vuetify-sidebar-template",
   "vuikit": "vuikit.netlify.com",
   "vuongdothanhhuy": "vuongdothanhhuy.github.io", // noCF? (don´t add this in a new PR)

--- a/cnames_active.js
+++ b/cnames_active.js
@@ -1596,8 +1596,8 @@ var cnames_active = {
   "vue-svg-loader": "vue-svg-loader.netlify.com",
   "vue-treeselect": "riophae.github.io/vue-treeselect",
   "vuejsindy": "vuejsindy.github.io",
-  "vuelog": "myst729.github.io/Vuelog",
   "vuelidate": "vuelidate.netlify.com",
+  "vuelog": "myst729.github.io/Vuelog",
   "vuetify-sidebar-template": "disjfa.github.io/vuetify-sidebar-template",
   "vuikit": "vuikit.netlify.com",
   "vuongdothanhhuy": "vuongdothanhhuy.github.io", // noCF? (don´t add this in a new PR)


### PR DESCRIPTION
We moved the popular Vue validation library Vuelidate to its own organization and now host it on Netlify.

We would like to use `vuelidate.js.org` as it's new domain.

- [x] There is reasonable content on the page (see: [No Content](https://github.com/js-org/js.org/wiki/No-Content))
- [x] I have read and accepted the [Terms and Conditions](http://js.org/terms.html)
