### PR TITLE
div.js.org

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -392,7 +392,7 @@ var cnames_active = {
   "distillery": "achannarasappa.github.io/distillery", // noCF? (don´t add this in a new PR)
   "distri": "flarp.github.io/Distri.js",
   "distribution": "distributionjs.github.io/website",
-  "div": "div-js.github.io",
+  "div": "div-js.github.io/div.js.org",
   "djinn-state": "djinn-state.github.io/djinn-state",
   "djsbasics": "djsbasics.gitlab.io/mkdocs",
   "djvu": "russcoder.github.io/djvujs", // noCF


### PR DESCRIPTION

repo name: div-js.github.io -> div.js.org
Therefore, hereafter you should go to "div-js.github.io/div.js.org" to see the gh-pages.
I couldn't use the "gh-pages" branch due to the github terms which is referred [here](https://help.github.com/en/articles/configuring-a-publishing-source-for-github-pages).

- [x] There is reasonable content on the page (see: [No Content](https://github.com/js-org/js.org/wiki/No-Content))
- [x] I have read and accepted the [Terms and Conditions](http://js.org/terms.html)
