### PR TITLE
docs.storybook.js.org

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -402,7 +402,6 @@ var cnames_active = {
   "dna": "dnajs.github.io/dna.js",
   "dns": "js-org.github.io/dns.js.org",
   "docile": "teamtofu.github.io/docile",
-  "docs.storybook": "storybook-docs.netlify.com", // noCF
   "docsify": "docsifyjs.github.io/docsify",
   "docsify-es": "sidval.github.io/docsify-es",
   "docsify-ru": "truepatch.github.io/docsify-ru",


### PR DESCRIPTION
Reverts js-org/js.org#2798

Sorry for the undo here. We ended up hosting the docs content under a subdirectory, so we don't need the separate domain after all.

Thanks for your patience and help on this @indus @MattIPv4 😄 
