### PR TITLE
charge.js.org

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -266,6 +266,7 @@ var cnames_active = {
   "chaaat": "chaaat.github.io",
   "chain-able": "fluents.github.io/chain-able-site",
   "chatexchange": "jacob-gray.github.io/ChatExchangeJS",
+  "charge": "brandonweiss.github.io/charge",
   "chartconstructor": "quarksworks.github.io/chartConstructor",
   "chandzhang": "chandzhang.github.io",
   "cheerio": "cheeriojs.github.io/cheerio",


### PR DESCRIPTION
- [x] There is reasonable content on the page (see: [No Content](https://github.com/js-org/js.org/wiki/No-Content))
- [x] I have read and accepted the [Terms and Conditions](http://js.org/terms.html)

I’d like to use this subdomain for the docs for [Charge](https://github.com/brandonweiss/charge). Thanks!

P.S. There is content but it looks broken and unstyled because GitHub uses a sub-directory (brandoweiss.github.io/charge) but the stylesheet and image links use absolute URLs (without a domain/hostname). As soon as it’s using a custom sub-domain all the links will work correctly!
