### PR TITLE
srvr.js.org

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -1450,7 +1450,6 @@ var cnames_active = {
   "squeak": "bertfreudenberg.github.io/SqueakJS",
   "squirrelly": "hosting.gitbook.com", // noCF
   "sri": "jackub.github.io/subresource-integrity-fallback",
-  "srvr": "srvrjs.github.io/srvr",
   "stabs": "wnda.github.io/stabs",
   "stahlstadt": "dist1.storyblok.com",
   "stampit": "stampit-org.gitbook.io/docs",


### PR DESCRIPTION
Hello,

I would like to remove srvr.js.org. I created it here: https://github.com/js-org/js.org/pull/2482

Thanks!

- [x] There is reasonable content on the page (see: [No Content](https://github.com/js-org/js.org/wiki/No-Content))
- [x] I have read and accepted the [Terms and Conditions](http://js.org/terms.html)
