### PR TITLE
surabaya.js.org / sub.js.org

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -1500,7 +1500,6 @@ var cnames_active = {
   "super-controls": "thebearingedge.github.io/super-controls",
   "super-trim": "beeblebrox3.github.io/super-trim",
   "supernova": "janbiasi.github.io/supernova", // noCF? (don´t add this in a new PR)
-  "surabaya": "surabayajs.now.sh", // noCF? (don´t add this in a new PR)
   "iamsurajdc": "iamsurajdc.github.io",
   "sutanlab": "sutanlab.github.io.github.io",
   "svelteui": "transpiling.github.io/svelte-flat-ui",

--- a/cnames_active.js
+++ b/cnames_active.js
@@ -1492,7 +1492,6 @@ var cnames_active = {
   "styled-css-grid": "styled-css-grid.netlify.com",
   "styled-icons": "styled-icons.netlify.com",
   "stylis": "thysultan.github.io/stylis.js",
-  "sub": "subjs.github.io",
   "sudarshan": "sudarshanRaul.github.io",
   "sudoku": "andreynering.github.io/sudoku",
   "suka": "sukkaw.github.io",
@@ -1501,7 +1500,7 @@ var cnames_active = {
   "super-controls": "thebearingedge.github.io/super-controls",
   "super-trim": "beeblebrox3.github.io/super-trim",
   "supernova": "janbiasi.github.io/supernova", // noCF? (don´t add this in a new PR)
-  "surabaya": "surabayajs.github.io",
+  "surabaya": "surabayajs.now.sh",
   "iamsurajdc": "iamsurajdc.github.io",
   "sutanlab": "sutanlab.github.io.github.io",
   "svelteui": "transpiling.github.io/svelte-flat-ui",

--- a/cnames_active.js
+++ b/cnames_active.js
@@ -1500,7 +1500,7 @@ var cnames_active = {
   "super-controls": "thebearingedge.github.io/super-controls",
   "super-trim": "beeblebrox3.github.io/super-trim",
   "supernova": "janbiasi.github.io/supernova", // noCF? (don´t add this in a new PR)
-  "surabaya": "surabayajs.now.sh",
+  "surabaya": "surabayajs.now.sh", // noCF? (don´t add this in a new PR)
   "iamsurajdc": "iamsurajdc.github.io",
   "sutanlab": "sutanlab.github.io.github.io",
   "svelteui": "transpiling.github.io/svelte-flat-ui",


### PR DESCRIPTION
- [x] There is reasonable content on the page (see: [No Content](https://github.com/js-org/js.org/wiki/No-Content))
- [x] I have read and accepted the [Terms and Conditions](http://js.org/terms.html)

---

### Description

`sub` subdomain is no longer used and `surabaya` subdomain now using ZEIT Now deployment with the deployment URL is <https://surabayajs.now.sh>

### Requested

```diff
- "sub": "subjs.github.io",
- "surabaya": "surabayajs.github.io",
+ "surabaya": "surabayajs.now.sh",
```

### Screenshot

![image](https://user-images.githubusercontent.com/8220954/56834209-fc615400-689a-11e9-887c-c100bd2d8936.png)