### PR TITLE
cq-websocket.js.org

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -345,6 +345,7 @@ var cnames_active = {
   "country": "growmies.github.io/countryjs", // noCF? (don´t add this in a new PR)
   "cp": "nestedobjects.github.io/cp",
   "cplayer": "copay.github.io/cPlayer",
+  "cq-websocket": "momocow.github.io/cq-websocket",
   "cqrs": "adrai.github.io/cqrs", // noCF? (don´t add this in a new PR)
   "cr": "echosoar.github.io/cr",
   "cracked": "billorcutt.github.io/Cracked",

--- a/cnames_active.js
+++ b/cnames_active.js
@@ -345,7 +345,7 @@ var cnames_active = {
   "country": "growmies.github.io/countryjs", // noCF? (don´t add this in a new PR)
   "cp": "nestedobjects.github.io/cp",
   "cplayer": "copay.github.io/cPlayer",
-  "cq-websocket": "momocow.github.io/cq-websocket",
+  "cq-websocket": "momocow.github.io/node-cq-websocket",
   "cqrs": "adrai.github.io/cqrs", // noCF? (don´t add this in a new PR)
   "cr": "echosoar.github.io/cr",
   "cracked": "billorcutt.github.io/Cracked",


### PR DESCRIPTION
- [x] There is reasonable content on the page (see: [No Content](https://github.com/js-org/js.org/wiki/No-Content))

The document is provided under the `/docs` folder of the repository ([link](https://github.com/momocow/node-cq-websocket/tree/master/docs)). It's written in markdown and rendered by GitHub with a builtin theme.

- [x] I have read and accepted the [Terms and Conditions](http://js.org/terms.html)

----

The requested cname is `cq-websocket` while the repository is named `node-cq-websocket`. I think the `node-` prefix should be one of those exceptions mentioned in the [wiki](https://github.com/js-org/js.org/wiki/Subdomain-Determination#exceptions), which is also commonly ignored by NPM CLI when `npm init`.

Actually the project name on the NPM registry is [`cq-websocket`](https://www.npmjs.com/package/cq-websocket). The `node-` prefix has its historical reason, since it was a Node-only project but it has extended its support for browser since `v1.5.0` ([CHANGELOG](https://github.com/momocow/node-cq-websocket/blob/master/docs/CHANGELOG-v1.md#v150)).

If the rename for the repository is required, please let me know.
Thanks for the nice service. 😄 