### PR TITLE
mailgo.js.org

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -904,7 +904,7 @@ var cnames_active = {
   "magnet": "magnetjs.github.io/Magnet", // noCF? (don´t add this in a new PR)
   "mahdyar": "mahdyar.github.io/mahdyar.js.org",
   "mahmoud": "mahmoud-sagharjoughi.github.io/mahmoud",
-  "mailgo": "manzinello.github.io/mailgo",
+  "mailgo": "manzinello.github.io/mailgo.js.org",
   "majestic": "moityjs.github.io/majestic",
   "maker": "microsoft.github.io/maker.js",
   "mali": "malijs.github.io",


### PR DESCRIPTION
I've changed the repo for the docs (mailgo.js.org) for my project **mailgo**. In the new repo there is already the _gh-pages_ branch with the most updated website and the _CNAME_ file.

- [x] There is reasonable content on the page (see: [No Content](https://github.com/js-org/js.org/wiki/No-Content))
- [x] I have read and accepted the [Terms and Conditions](http://js.org/terms.html)
