### PR TITLE
lab.js.org

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -837,7 +837,7 @@ var cnames_active = {
   "ktm": "developers-nepal.github.io/ktmjs",
   "kyoto": "kyotojs.github.io",
   "l2dwidget": "xiazeyu.github.io/live2d-widget.js-doc",
-  "lab": "felixhenninger.github.io/lab.js",
+  "lab": "labjs.netlify.com",
   "labelauty": "fntneves.github.io/jquery-labelauty", // noCF? (don´t add this in a new PR)
   "lad": "ladjs.github.io/lad",
   "lambda": "lambdajs.github.io", // noCF? (don´t add this in a new PR)


### PR DESCRIPTION
- [x] There is reasonable content on the page (see: [No Content](https://github.com/js-org/js.org/wiki/No-Content))
- [x] I have read and accepted the [Terms and Conditions](http://js.org/terms.html)

Hi there, fine folks of `js.org`!

We've moved our site from GitHub pages to Netlify so that we can host more complex content, and would be thrilled if you could redirect the domain. 

Thanks so much!

-Felix