### PR TITLE
node.js.org

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -1092,6 +1092,7 @@ var cnames_active = {
   "nite": "manvalls.github.io/nite",
   "noblox": "suufi.github.io/noblox.js",
   "nod": "diegohaz.github.io/nod",
+  "node": "trott.github.io/node.js.org",
   "node-atlas": "haeresis.github.io/NodeAtlas",
   "node-slate": "center-key.github.io/node-slate",
   "nodegarden": "pakastin.github.io/nodegarden",


### PR DESCRIPTION
Yes, it's a prominent project. I'm one of the most prolific contributors
the last few years, I'm on the project's Technical Steering Committee,
and the web folks have explicitly expressed skepticism about doing this.
I'm just grabbing it to redirect to the main Node.js site to prevent
anyone from using it to redirect to evilsite.example.com. I'll happily
hand it over to the nodejs GitHub org if they want it (and, in fact, I'd
almost assuredly be the person doing the transfer as I'm one of the
owner's of that org).

- [x] There is reasonable content on the page (see: [No Content](https://github.com/js-org/js.org/wiki/No-Content))
- [x] I have read and accepted the [Terms and Conditions](http://js.org/terms.html)
