### PR TITLE
Fix typo in cname file

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -708,7 +708,7 @@ var cnames_active = {
   "hyperapp": "hyperapp.github.io",
   "hyperform": "hyperform.github.io",
   "hyperhtml-styleguide": "albertosantini.github.io/hyperhtml-styleguide", // noCF
-  "hytalebrasil: "hytalebrasil.github.io",
+  "hytalebrasil": "hytalebrasil.github.io",
   "i18n4v": "shibukawa.github.io/i18n4v",
   "iagrib": "iagrib.github.io",
   "icecast": "jucrouzet.github.io/icecast.js",


### PR DESCRIPTION
Fix a type introduced in https://github.com/js-org/js.org/pull/3109

- [x] There is reasonable content on the page (see: [No Content](https://github.com/js-org/js.org/wiki/No-Content)) N/A
- [x] I have read and accepted the [Terms and Conditions](http://js.org/terms.html)

Interesting enough https://hytalebrasil.js.org/ loads even with this typo.