### PR TITLE
node.js.org

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -1094,7 +1094,7 @@ var cnames_active = {
   "nite": "manvalls.github.io/nite",
   "noblox": "suufi.github.io/noblox.js",
   "nod": "diegohaz.github.io/nod",
-  "node": "trott.github.io/node.js.org",
+  "node": "nodejs.github.io/node.js.org",
   "node-atlas": "haeresis.github.io/NodeAtlas",
   "node-slate": "center-key.github.io/node-slate",
   "nodegarden": "pakastin.github.io/nodegarden",


### PR DESCRIPTION
The node.js.org repo was transferred to the nodejs org. Reflect that in the cnames file.

- [x] There is reasonable content on the page (see: [No Content](https://github.com/js-org/js.org/wiki/No-Content))
- [x] I have read and accepted the [Terms and Conditions](http://js.org/terms.html)
