### PR TITLE
gtfs.js.org

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -652,6 +652,7 @@ var cnames_active = {
   "gridsplit": "assetinfo.github.io", // noCF? (don´t add this in a new PR)
   "gruft": "nikola.github.io/gruft", // noCF? (don´t add this in a new PR)
   "grumpy": "cringiest.github.io/grumpy",
+  "gtfs": "gtfs-js.github.io/gtfs.js.org",
   "guilherme": "guilhermedelemos.github.io/guilherme",
   "guillotine": "matiasgagliano.github.io/guillotine", // noCF? (don´t add this in a new PR)
   "guineapigbot": "guineapigbot.github.io",


### PR DESCRIPTION
We are starting a GTFS organization on github and want to put documentation for our common tools on this webpage

- [x] There is reasonable content on the page (see: [No Content](https://github.com/js-org/js.org/wiki/No-Content))
- [x] I have read and accepted the [Terms and Conditions](http://js.org/terms.html)
