### PR TITLE
pulse.js.org

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -1287,6 +1287,7 @@ var cnames_active = {
   "ps": "spindlyskit.github.io/ps.js",
   "pubg": "ickerio.github.io/pubg.js",
   "published": "fiverr.github.io/published",
+  "pulse": "alias.zeit.co",
   "pure": "fengzilong.github.io/pure",
   "purpzie": "purpzie.github.io/site",
   "pwa-cookbook": "sylvainpolletvillard.github.io/pwa-cookbook",

--- a/cnames_active.js
+++ b/cnames_active.js
@@ -1287,7 +1287,7 @@ var cnames_active = {
   "ps": "spindlyskit.github.io/ps.js",
   "pubg": "ickerio.github.io/pubg.js",
   "published": "fiverr.github.io/published",
-  "pulse": "alias.zeit.co",
+  "pulse": "alias.zeit.co", //noCF
   "pure": "fengzilong.github.io/pure",
   "purpzie": "purpzie.github.io/site",
   "pwa-cookbook": "sylvainpolletvillard.github.io/pwa-cookbook",


### PR DESCRIPTION
- [x] There is reasonable content on the page (see: [No Content](https://github.com/js-org/js.org/wiki/No-Content))
- [x] I have read and accepted the [Terms and Conditions](http://js.org/terms.html)

Since this is a zeit's now page it does not use github pages, you can see the docs here that it will be pointing to at https://pulsejs-docs.ijamespine.now.sh

The repo for the docs is here: https://github.com/jamiepine/pulse

Because this is zeit's now I'll also need a TXT record with the following options if possible.

Name: `_now`
Value: `QmVJq8GbX4suj9cTVRHy4ARjZHqkHgAzCBP8PLFbqx1bxj`