### PR TITLE
veza.js.org

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -1771,6 +1771,7 @@ var cnames_active = {
   "vendywira": "vendywira.github.io",
   "verifyr": "arze1.github.io/verifyr-site",
   "verse": "druidic.github.io/verse",
+  "veza": "kyranet.github.io/veza",
   "viav": "brandondyer64.github.io/viav",
   "vico": "bohdantkachenko.github.io/vico", // noCF? (don´t add this in a new PR)
   "victor": "mrdatastorage.github.io/victor",


### PR DESCRIPTION
- [x] There is reasonable content on the page (see: [No Content](https://github.com/js-org/js.org/wiki/No-Content))
- [x] I have read and accepted the [Terms and Conditions](http://js.org/terms.html)

Adds veza.js.org, the `CNAME` file is available [here](https://github.com/kyranet/veza/blob/gh-pages/CNAME).