### PR TITLE
mduleone.js.org && craps.js.org

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -385,6 +385,7 @@ var cnames_active = {
   "cqrs": "adrai.github.io/cqrs", // noCF? (don´t add this in a new PR)
   "cr": "echosoar.github.io/cr",
   "cracked": "billorcutt.github.io/Cracked",
+  "craps": "mduleone.github.io/craps",
   "create-project": "chalarangelo.github.io/create-js-project",
   "createrest": "atomixinteractions.github.io/createrest",
   "creaturegen": "ryancromebook.github.io/creaturegen",
@@ -1017,6 +1018,7 @@ var cnames_active = {
   "mc": "magicarbon.github.io/mc", // noCF? (don´t add this in a new PR)
   "mcul": "teamtofu.github.io/mcul",
   "mde": "lukehorvat.github.io/mde-soundboard",
+  "mduleone": "mduleone.github.io",
   "mechan": "dusterthefirst.github.io/mechan.js",
   "medan": "medan-js.github.io", // noCF
   "mediainfo": "buzz.github.io/mediainfo.js",


### PR DESCRIPTION
- [x] There is reasonable content on the page (see: [No Content](https://github.com/js-org/js.org/wiki/No-Content))
- [x] I have read and accepted the [Terms and Conditions](http://js.org/terms.html)

Hi! I'm a little confused if I'm able to set my pages up with `*.js.org` domains.

I currently have a CNAME on my `mduleone.github.io` repository that redirects to `https://dule.one`, and as a result, `mduleone.github.io/craps` also automatically redirects to `https://dule.one/craps`.

I've added the lines to the `cnames_active.js` file, but I'm not sure how nicely my existing set up will play with these. Thanks for your time!