### PR TITLE
channel.js.org / repeater.js.org

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -305,7 +305,6 @@ var cnames_active = {
   "chaaat": "chaaat.github.io",
   "chain-able": "fluents.github.io/chain-able-site",
   "chandzhang": "chandzhang.github.io",
-  "channel": "channeljs.github.io/channel",
   "charge": "charge-js.netlify.com",
   "chartconstructor": "quarksworks.github.io/chartConstructor",
   "chatexchange": "jacob-gray.github.io/ChatExchangeJS",
@@ -1455,6 +1454,7 @@ var cnames_active = {
   "rengular": "chigix.github.io/rengular",
   "renovate": "sawyerbx.github.io/renovate",
   "repackage": "cchamberlain.github.io/repackage", // noCF? (don´t add this in a new PR)
+  "repeater": "repeaterjs.github.io/repeater",
   "replace": "quales.github.io/replace.js",
   "request": "request.gitbooks.io", // noCF? (don´t add this in a new PR)
   "reshape": "reshape.netlify.com",


### PR DESCRIPTION
- [x] There is reasonable content on the page (see: [No Content](https://github.com/js-org/js.org/wiki/No-Content))
- [x] I have read and accepted the [Terms and Conditions](http://js.org/terms.html)

I’ve changed the name of the library and would like to 1. free up channel.js.org and 2. use repeater.js.org. Sorry for the churn!

Related issue and PR:
https://github.com/repeaterjs/repeater/issues/18
https://github.com/repeaterjs/repeater/pull/28