### PR TITLE
quantlib.js.org

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -999,6 +999,7 @@ var cnames_active = {
   "pwa-cookbook": "sylvainpolletvillard.github.io/pwa-cookbook",
   "pwa-workshop": "sylvainpolletvillard.github.io/pwa-workshop",
   "qs": "kirjs.github.io/qs.js", // noCF? (don´t add this in a new PR)
+  "quantlib": "quantlibjs.github.io",
   "querybuilder": "mistic100.github.io/jQuery-QueryBuilder", // noCF? (don´t add this in a new PR)
   "question": "teamtofu.github.io/questionify",
   "quickdb": "truexpixels.gitbooks.io/quickdb",


### PR DESCRIPTION
Hello, I released the first version of quantlib.js it's located at https://quantlibjs.github.io/ql.mjs

quantlib.js is re-implemetation of [quantlib](https://github.com/lballabio/QuantLib) using typescript/javascript

my website: https://quantlibjs.github.io/ allow user to select test case or example from top menu, which will display script on left panel, and run test on right panel using jasmine standalone web versoin.

![image](https://user-images.githubusercontent.com/29996911/64322073-6c73a980-cff4-11e9-9433-3928631538f4.png)
![image](https://user-images.githubusercontent.com/29996911/64322085-73022100-cff4-11e9-8a84-305e65405621.png)

please note that the test cases or examples are not completed yet, i will complete and add in the future (example menu only fra works right now)

please assign quantlib.js.org to quantlibjs.github.io, thank you!