### PR TITLE
tslib-cli.js.org

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -1786,6 +1786,7 @@ var cnames_active = {
   "ts-react-boilerplate": "lapanti.github.io/ts-react-boilerplate",
   "ts2jsdoc": "spatools.github.io/ts2jsdoc", // noCF? (don´t add this in a new PR)
   "tsdi": "knisterpeter.github.io/tsdi",
+  "tslib-cli": "hosting.gitbook.com",
   "ttag": "ttag-org.github.io/ttag",
   "ttgprotect": "ttgprotect.github.io",
   "tui-nuxt": "hosting.gitbook.com", // noCF


### PR DESCRIPTION
Adds tslib-cli.js.org. Content at https://tslib-cli.gitbook.io/tslib-cli/

- [x] There is reasonable content on the page (see: [No Content](https://github.com/js-org/js.org/wiki/No-Content))
- [x] I have read and accepted the [Terms and Conditions](http://js.org/terms.html)
