### PR TITLE
bottender.js.org

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -254,7 +254,7 @@ var cnames_active = {
   "bootstrap-vue-arsenic": "ycs77.github.io/bootstrap-vue-arsenic",
   "bornaeon": "bornaeon.github.io",
   "botgram": "botgram.github.io/botgram",
-  "bottender": "bottenderjs.github.io",
+  "bottender": "yoctol.github.io/bottender",
   "boundless": "enigma-io.github.io/boundless",
   "box": "capacitorset.github.io/box-js", // noCF
   "brain": "brainjs.github.io/brain.js.org",


### PR DESCRIPTION
We are now migrating Bottender website from `bottenderjs.github.io` to `yoctol.github.io/bottender`

- [x] There is reasonable content on the page (see: [No Content](https://github.com/js-org/js.org/wiki/No-Content))
- [x] I have read and accepted the [Terms and Conditions](http://js.org/terms.html)
