### PR TITLE
ember-electron.js.org

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -548,7 +548,7 @@ var cnames_active = {
   "email-templates": "niftylettuce.github.io/email-templates",
   "embedlam": "wnda.github.io/embedlam",
   "ember-cli-page-object": "san650.github.io/ember-cli-page-object", // noCF? (don´t add this in a new PR)
-  "ember-electron": "felixrieseberg.github.io/ember-electron",
+  "ember-electron": "adopted-ember-addons.github.io/ember-electron",
   "emeraldcraftmc": "emeraldcraftmc.github.io", // noCF? (don´t add this in a new PR)
   "emoji": "egoist.github.io/emoji",
   "emojipanel": "danbovey.github.io/EmojiPanel",


### PR DESCRIPTION
- [x] There is reasonable content on the page (see: [No Content](https://github.com/js-org/js.org/wiki/No-Content))
- [x] I have read and accepted the [Terms and Conditions](http://js.org/terms.html)

The `ember-electron` repo was migrated from @felixrieseberg to the `adopted-ember-addons` organization, so we'd like to update the CNAME to point to the new URL.

I haven't added the CNAME file to the branch yet because I don't know what approval/verification process you need to go through or whatever since this is a pre-existing domain, so I want to wait until that is complete before adding the CNAME file and breaking our existing github.io URL. So please let me know when you're convinced that this CNAME change is permissible, and I'll add the CNAME file.