### PR TITLE
redux-undo.js.org

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -1546,7 +1546,7 @@ var cnames_active = {
   "redux-starter-kit": "redux-starter-kit-docs.netlify.com",
   "redux-tiles": "bloomca.github.io/redux-tiles",
   "redux-toolkit": "redux-starter-kit-docs.netlify.com",
-  "redux-undo": "omnidan.github.io/redux-undo", // noCF? (don´t add this in a new PR)
+  "redux-undo": "hosting.gitbook.com",
   "redux-webpack-boilerplate": "cchamberlain.github.io/redux-webpack-boilerplate", // noCF? (don´t add this in a new PR)
   "reduxible": "pitzcarraldo.github.io/reduxible", // noCF? (don´t add this in a new PR)
   "refract": "hosting.gitbook.com",


### PR DESCRIPTION
we already have an existing js.org page on github pages, but are now moving to the latest gitbook version, which requires hosting on gitbook.com

you can check the contents of the new gitbook page here (temporarily on my own domain until this gets merged): https://redux-undo.omnidan.net/

- [x] There is reasonable content on the page (see: [No Content](https://github.com/js-org/js.org/wiki/No-Content))
- [x] I have read and accepted the [Terms and Conditions](http://js.org/terms.html)
