### PR TITLE
mockyeah.js.org

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -1110,7 +1110,7 @@ var cnames_active = {
   "mobx-state-tree": "mobxjs.github.io/mobx-state-tree",
   "mock-middleware": "luobotang.github.io/mock-middleware",
   "mockjs-lite": "52cik.github.io/mockjs-lite", // noCF
-  "mockyeah": "mockyeah.github.io/mockyeah",
+  "mockyeah": "mockyeah.netlify.com",
   "modbot": "modbotjs.github.io",
   "modofun": "modofunjs.github.io/modofun",
   "modoki": "araozu.github.io/modoki",


### PR DESCRIPTION
- [x] There is reasonable content on the page (see: [No Content](https://github.com/js-org/js.org/wiki/No-Content))
- [x] I have read and accepted the [Terms and Conditions](http://js.org/terms.html)

Hello! A maintainer of [mockyeah](https://github.com/mockyeah/mockyeah) here. We're moving our docs site from GitHub Pages to Netlify (see this issue https://github.com/mockyeah/mockyeah/issues/529). The new site is live here https://mockyeah.netlify.com, so we'd like to move https://mockyeah.js.org to point there instead of http://mockyeah.github.io/mockyeah. Thanks!