### PR TITLE
eiphop.js.org

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -518,6 +518,7 @@ var cnames_active = {
   "ed2k": "sunnyli.github.io/ed2k.js",
   "ef": "classicoldsong.github.io/ef.js.org",
   "effectful": "awto.github.io/effectfuljs",
+  "eiphop": "eiphop.netlify.com",
   "ejir": "ejir.github.io",
   "elastic-builder": "sudo-suhas.github.io/elastic-builder",
   "electron-react-boilerplate": "electron-react-boilerplate.github.io/site",


### PR DESCRIPTION
- [x] There is reasonable content on the page (see: [No Content](https://github.com/js-org/js.org/wiki/No-Content))
- [x] I have read and accepted the [Terms and Conditions](http://js.org/terms.html)

Hi Mods!

I've been working on [krimlabs/eiphop](https://github.com/krimlabs/eiphop) for a few months now. It's a fetch like abstraction for electron's ipc. Would be great if we can use js.org domain for the project.

You can check the site here: https://eiphop.netlify.com
Here are some screenshots to prove content:

|  |  |  
|---|---|
| ![Screenshot 2020-01-06 at 1 58 07 PM](https://user-images.githubusercontent.com/1925158/71805685-d7a9b700-308c-11ea-8c33-54f5291c74eb.png) | ![Screenshot 2020-01-06 at 1 58 16 PM](https://user-images.githubusercontent.com/1925158/71805687-d7a9b700-308c-11ea-9beb-22a6d47ec0e5.png) | 
| ![Screenshot 2020-01-06 at 1 58 22 PM](https://user-images.githubusercontent.com/1925158/71805689-d8424d80-308c-11ea-86ca-6918311f7a6b.png) | ![Screenshot 2020-01-06 at 1 58 29 PM](https://user-images.githubusercontent.com/1925158/71805690-d8424d80-308c-11ea-9cfb-43ac003465f6.png) |

Many thanks :)
