### PR TITLE
prismic-nuxt.js.org

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -1353,7 +1353,7 @@ var cnames_active = {
   "pretty-print-json": "center-key.github.io/pretty-print-json",
   "prettylog": "moosecoop.github.io/PrettyLog",
   "prismarine": "prismarinejs.github.io",
-  "prismic-nuxt": "jamespegg.github.io/prismic-nuxt",
+  "prismic-nuxt": "nuxt-community.github.io/prismic-nuxt",
   "pristine": "sha256.github.io/Pristine", //noCF
   "producify": "jesobreira.github.io/producify",
   "producthunt-trending": "xiaomingplus.github.io/producthunt-trending",


### PR DESCRIPTION
Repo has been transferred, this PR updated the new repo url :)

- [x] There is reasonable content on the page (see: [No Content](https://github.com/js-org/js.org/wiki/No-Content))
- [x] I have read and accepted the [Terms and Conditions](http://js.org/terms.html)
