### PR TITLE
docs.light.js.org

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -474,6 +474,7 @@ var cnames_active = {
   "dna": "dnajs.github.io/dna.js",
   "dns": "js-org.github.io/dns.js.org",
   "docile": "teamtofu.github.io/docile",
+  "docs.light": "hosting.gitbook.com", // noCF
   "docsify": "docsifyjs.github.io/docsify",
   "docsify-es": "sidval.github.io/docsify-es",
   "docsify-ru": "truepatch.github.io/docsify-ru",


### PR DESCRIPTION
Hello,

I remember reading a post about sub-sub domains being allowed, but if not, I can close this PR.

I wanted to create a link to the documentation page hosted by GitBook. Here is the content on the page: https://lightjs.gitbook.io/light/

Additionally, I am the owner of light.js.org: https://github.com/js-org/js.org/pull/2974

Thank you

- [x] There is reasonable content on the page (see: [No Content](https://github.com/js-org/js.org/wiki/No-Content))
- [x] I have read and accepted the [Terms and Conditions](http://js.org/terms.html)
