### PR TITLE
single-spa.js.org

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -1639,7 +1639,7 @@ var cnames_active = {
   "sina": "sinabakh.github.io/sina",
   "singh": "gxjit.github.io",
   "single-page-web-app": "lukejpreston.github.io/single-page-web-app",
-  "single-spa": "canopytax.github.io/single-spa.js.org",
+  "single-spa": "single-spa.github.io/single-spa.js.org",
   "sirkit": "seckwei.github.io/SirKit_CircuitSim", // noCF? (don´t add this in a new PR)
   "sistersbio": "KDiaCodes.github.io/SistersBio",
   "sizle": "christoga.github.io/sizle", // noCF? (don´t add this in a new PR)


### PR DESCRIPTION
- [x] There is reasonable content on the page (see: [No Content](https://github.com/js-org/js.org/wiki/No-Content))
- [x] I have read and accepted the [Terms and Conditions](http://js.org/terms.html)

We recently transferred the single-spa repo from https://github.com/CanopyTax/single-spa to https://github.com/single-spa/single-spa. You can verify this by going to the first URL and noticing the redirect to the second.

This PR updates the domain js.org uses so we don't rely on Github's redirect behavior forevermore. Specifically certain links, such as https://single-spa.js.org/docs/api are redirecting to the wrong page and I think it might be because of the expectation that it is still hosted at canopytax.github.io