### PR TITLE
arda.js.org

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -146,7 +146,6 @@ var cnames_active = {
   "aprende-react": "ptcc.github.io/aprende-react",
   "arc": "diegohaz.github.io/arc",
   "arcn": "alexakasanjeev.github.io/arcn",
-  "arda": "ardasoyturk.github.io",
   "argo": "albertosantini.github.io/argo", // noCF? (don´t add this in a new PR)
   "ari": "arbo77.github.io/ari",
   "arief": "1997arief.github.io",


### PR DESCRIPTION
Per https://github.com/js-org/js.org/pull/2386#issuecomment-578211025 - content is no longer valid and they do not need the domain anymore

- [x] There is reasonable content on the page (see: [No Content](https://github.com/js-org/js.org/wiki/No-Content))
- [x] I have read and accepted the [Terms and Conditions](http://js.org/terms.html)
