### PR TITLE
zen.js.org.

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -2021,6 +2021,7 @@ var cnames_active = {
   "zea-engine": "zeainc.github.io/zea-engine",
   "zea-ux": "zeainc.github.io/zea-ux",
   "zeit": "urvinh.github.io",
+  "zen": "tomelam.github.io/zen",
   "zentor": "zentor.github.io",
   "zephyr": "zephyr-dh.github.io/zephyr",
   "zeroframe": "filips123.github.io/ZeroFrameJS",


### PR DESCRIPTION
I have added a line to cnames_active.js to create the domain zen.js.org, but I do not have a CNAME file in the repo tomelam.github.io/zen  because when I add one with the single line "zen.js.org", tomelam.github.io/zen gets a redirect to zen.js.org and that returns a 404.

- [x] There is reasonable content on the page (see: [No Content](https://github.com/js-org/js.org/wiki/No-Content))
- [x] I have read and accepted the [Terms and Conditions](http://js.org/terms.html)
