### PR TITLE
reactiflux.js.org

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -1466,6 +1466,7 @@ var cnames_active = {
   "reactabular": "bebraw.github.io/reactabular",
   "reactdesktop": "gabrielbull.github.io/react-desktop", // noCF? (don´t add this in a new PR)
   "reactif": "reactif.netlify.com",
+  "reactiflux": "reactiflux.netlify.com",
   "reactour": "elrumordelaluz.github.io/reactour",
   "reactql": "leebenson.github.io/reactql-site",
   "readcolor": "keiww.github.io/readcolorhex",


### PR DESCRIPTION
Our old domain (reactiflux.com) expired, and we're considering redirecting reactiflux.js.org to reactiflux.netlify.com (our existing site) as a fallback option.

- [x] There is reasonable content on the page (see: [No Content](https://github.com/js-org/js.org/wiki/No-Content))
- [x] I have read and accepted the [Terms and Conditions](http://js.org/terms.html)
