### PR TITLE
bootstrap-vue.js.org

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -256,7 +256,7 @@ var cnames_active = {
   "booru": "atlasthebot.github.io/booru",
   "bootstrap-confirmation": "mistic100.github.io/Bootstrap-Confirmation", // noCF? (don´t add this in a new PR)
   "bootstrap-validate": "pascalebeier.github.io/bootstrap-validate",
-  "bootstrap-vue": "bootstrap-vue.github.io",
+  "bootstrap-vue": "alias.zeit.co",
   "bootstrap-vue-arsenic": "ycs77.github.io/bootstrap-vue-arsenic",
   "bornaeon": "bornaeon.github.io",
   "botgram": "botgram.github.io/botgram",

--- a/cnames_active.js
+++ b/cnames_active.js
@@ -256,7 +256,7 @@ var cnames_active = {
   "booru": "atlasthebot.github.io/booru",
   "bootstrap-confirmation": "mistic100.github.io/Bootstrap-Confirmation", // noCF? (don´t add this in a new PR)
   "bootstrap-validate": "pascalebeier.github.io/bootstrap-validate",
-  "bootstrap-vue": "alias.zeit.co",
+  "bootstrap-vue": "alias.zeit.co", // noCF
   "bootstrap-vue-arsenic": "ycs77.github.io/bootstrap-vue-arsenic",
   "bornaeon": "bornaeon.github.io",
   "botgram": "botgram.github.io/botgram",


### PR DESCRIPTION
- [x] There is reasonable content on the page (see: [No Content](https://github.com/js-org/js.org/wiki/No-Content))
- [x] I have read and accepted the [Terms and Conditions](http://js.org/terms.html)

Note, we are in the process of migrating our hosting to Zeit Now, which requests to create an alias for `bootstrap-vue.js.org` to point to `alias.zeit.co`.

Currently the alias is pending at Zeit (until the CNAME record at js.org is updated), so you wont see our site at `alias.zeit.co`, but you can see the branch at `bootstrap-vue.now.sh` (the branch URL, and verify `bootstrap-vue.now.sh/CNAME`)
