### PR TITLE
italia.js.org

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -905,7 +905,7 @@ var cnames_active = {
   "isic": "isic.github.io/isic-docs",
   "islisp": "ta2gch.github.io/islisp.js.org",
   "istanbul": "istanbuljs.github.io",
-  "italia": "milano-js.github.io/italia-js", // noCF? (don´t add this in a new PR)
+  "italia": "italia-js.github.io",
   "itsashis4u": "itsashis4u.github.io", // noCF? (don´t add this in a new PR)
   "itunes-bridge": "angrykiller.github.io/iTunes-bridge",
   "iutdb": "xchairs.github.io/iutdb.github.io",


### PR DESCRIPTION
Hi, I'd like to assign this domain to the repo of my org. Previously Italia JS was under Milano JS as a sub org but now has its own repo.
In the next weeks, we'll start adding some content to the page, mostly to announce our online meetups.

Thanks

- [x] There is reasonable content on the page (see: [No Content](https://github.com/js-org/js.org/wiki/No-Content))
- [x] I have read and accepted the [Terms and Conditions](http://js.org/terms.html)
