### PR TITLE
emerald.js.org

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -594,6 +594,7 @@ var cnames_active = {
   "embedlam": "wnda.github.io/embedlam",
   "ember-cli-page-object": "san650.github.io/ember-cli-page-object", // noCF? (don´t add this in a new PR)
   "ember-electron": "adopted-ember-addons.github.io/ember-electron",
+  "emerald": "thelonelyforth.github.io",
   "emeraldcraftmc": "emeraldcraftmc.github.io", // noCF? (don´t add this in a new PR)
   "emoji": "egoist.github.io/emoji",
   "emoji-button": "joeattardi.github.io/emoji-button",


### PR DESCRIPTION
This subdomain (emerald) will be used for a discord bot I'm working on at the moment.
- [x] There is reasonable content on the page (see: [No Content](https://github.com/js-org/js.org/wiki/No-Content))
- [x] I have read and accepted the [Terms and Conditions](http://js.org/terms.html)
