### PR TITLE
meto.js.org

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -1184,7 +1184,7 @@ var cnames_active = {
   "metadata": "oknosoft.github.io/metadata.js",
   "metascraper": "microlinkhq.github.io/metascraper",
   "meth": "meth-meth-method.github.io/meth",
-  "meto": "misly16.github.io/metowebsite123",
+  "meto": "sites.bootstrapstudio.io",
   "metools": "yimogit.github.io/metools-plugin",
   "meyda": "meyda.github.io",
   "mf": "awto.github.io/mfjs-compiler", // noCF? (don´t add this in a new PR)


### PR DESCRIPTION
Content of the site can be seen at meto.misly.dev.
See https://github.com/js-org/js.org/issues/4022 for context.

- [x] There is reasonable content on the page (see: [No Content](https://github.com/js-org/js.org/wiki/No-Content))
- [x] I have read and accepted the [Terms and Conditions](http://js.org/terms.html)

Closes #4022