### PR TITLE
next-auth.js.org

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -1328,7 +1328,7 @@ var cnames_active = {
   "newbyte": "newbytee.github.io/newbyte",
   "newyear": "dndrbots.github.io/new_year_counter",
   "next": "zeit.github.io/next-site",
-  "next-auth": "alias.zeit.co",
+  "next-auth": "alias.zeit.co", // noCF?
   "nexus": "nexusjs.netlify.com",
   "nflow": "nflow-js.github.io", // noCF? (don´t add this in a new PR)
   "nfwyst": "nfwyst.github.io",

--- a/cnames_active.js
+++ b/cnames_active.js
@@ -1328,7 +1328,7 @@ var cnames_active = {
   "newbyte": "newbytee.github.io/newbyte",
   "newyear": "dndrbots.github.io/new_year_counter",
   "next": "zeit.github.io/next-site",
-  "next-auth": "next-auth-docs.now.sh",
+  "next-auth": "alias.zeit.co",
   "nexus": "nexusjs.netlify.com",
   "nflow": "nflow-js.github.io", // noCF? (don´t add this in a new PR)
   "nfwyst": "nfwyst.github.io",

--- a/cnames_active.js
+++ b/cnames_active.js
@@ -1328,6 +1328,7 @@ var cnames_active = {
   "newbyte": "newbytee.github.io/newbyte",
   "newyear": "dndrbots.github.io/new_year_counter",
   "next": "zeit.github.io/next-site",
+  "next-auth": "next-auth-docs.now.sh",
   "nexus": "nexusjs.netlify.com",
   "nflow": "nflow-js.github.io", // noCF? (don´t add this in a new PR)
   "nfwyst": "nfwyst.github.io",

--- a/cnames_active.js
+++ b/cnames_active.js
@@ -1328,7 +1328,7 @@ var cnames_active = {
   "newbyte": "newbytee.github.io/newbyte",
   "newyear": "dndrbots.github.io/new_year_counter",
   "next": "zeit.github.io/next-site",
-  "next-auth": "alias.zeit.co", // noCF?
+  "next-auth": "alias.zeit.co", // noCF
   "nexus": "nexusjs.netlify.com",
   "nflow": "nflow-js.github.io", // noCF? (don´t add this in a new PR)
   "nfwyst": "nfwyst.github.io",


### PR DESCRIPTION
Github: https://github.com/iaincollins/next-auth
My fork for docs: https://github.com/ndom91/next-auth

Will most likely consolidate the two in some form, but the `now.sh` URL will stay the same, so no changes will be required from js.org side.

@iaincollins

- [x] There is reasonable content on the page (see: [No Content](https://github.com/js-org/js.org/wiki/No-Content))
- [x] I have read and accepted the [Terms and Conditions](http://js.org/terms.html)
