### PR TITLE
teddy.js.org

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -1978,7 +1978,7 @@ var cnames_active = {
   "tayyab": "itayyab.github.io",
   "tead": "teadjs.github.io",
   "techy": "hosting.gitbook.com",
-  "teddy": "teddytags.github.io/website",
+  "teddy": "alias.zeit.co", // noCF
   "telaviv": "dustin-h.github.io/telaviv", // noCF? (don´t add this in a new PR)
   "telegraf": "telegraf.github.io/telegraf", // noCF? (don´t add this in a new PR)
   "teletype": "keyvank.github.io/teletype.js",


### PR DESCRIPTION
- [x] There is reasonable content on the page (see: [No Content](https://github.com/js-org/js.org/wiki/No-Content))
- [x] I have read and accepted the [Terms and Conditions](http://js.org/terms.html)
Since this is a vercel (zeit) domain, it should point to alias.zeit.co and also added the `noCF` comment(which is on almost all the other configured projects). Domain to be used is https://teddytags.now.sh