### PR TITLE
aider.js.org

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -95,6 +95,7 @@ var cnames_active = {
   "ahmad": "aruzikulov.github.io/ahmad",
   "ahmeterdgn": "ahmeterdgn.github.io",
   "ahooks": "ahooks.surge.sh",
+  "aider": "tjz101.github.io/aider-js-pages",
   "airtable-plus": "victorhahn.github.io/airtable-plus",
   "ais": "yunyoujun.github.io/ais.js",
   "ajaxable": "artf.github.io/ajaxable",


### PR DESCRIPTION
Add `adier`, a static website statistics assistant.

- [√] There is reasonable content on the page (see: [No Content](https://github.com/js-org/js.org/wiki/No-Content))
- [√] I have read and accepted the [Terms and Conditions](http://js.org/terms.html)
