### PR TITLE
Add a / to fix "page not found"

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -1063,7 +1063,7 @@ var cnames_active = {
   "kowalski": "k0walslk1.github.io",
   "kra": "kra-framework.github.io/kra-suite", // noCF
   "kremling": "canopytax.github.io/kremling.js.org",
-  "kreta-api-v3": "daaniiieel.github.io/kreta-api-v3",
+  "kreta-api-v3": "daaniiieel.github.io/kreta-api-v3/",
   "kshitij": "kshitij98.github.io",
   "kst": "lucaelin.github.io/KST", // noCF
   "ktm": "developers-nepal.github.io/ktmjs",


### PR DESCRIPTION
This is a weird error. If you visit https://daaniiieel.github.io/kreta-api-v3 **without** the slash at the end, you get a 404. If you visit https://daaniiieel.github.io/kreta-api-v3/ with the slash, everything is correct.

- [x] There is reasonable content on the page (see: [No Content](https://github.com/js-org/js.org/wiki/No-Content))
- [x] I have read and accepted the [Terms and Conditions](http://js.org/terms.html)
