### PR TITLE
isbot.js.org

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -972,6 +972,7 @@ var cnames_active = {
   "iro": "jaames.github.io/iro.js",
   "irouter": "alhaqhassan.github.io/irouter.js",
   "is": "arasatasaygin.github.io/is.js", // noCF? (don´t add this in a new PR)
+  "isbot": "gorangajic.github.io/isbot",
   "iscaptive": "marvnet.github.io/iscaptive",
   "isfa": "isfaaghyth.github.io",
   "ishan": "ishanthukral.github.io/ishan.js", // noCF? (don´t add this in a new PR)


### PR DESCRIPTION
Detect bots/crawlers/spiders using the user agent string.

The site itself **is a tool** and uses the package to determine whether a given user-agent string is a known crawler. It promotes the package with a link.

**Pull request awaiting this merge**: https://github.com/gorangajic/isbot/pull/80

**Screenshot**:
| ![](https://user-images.githubusercontent.com/516342/87637656-3bebb880-c74b-11ea-8df5-afb7cf6f5aa2.png)
| -

- [x] There is reasonable content on the page (see: [No Content](https://github.com/js-org/js.org/wiki/No-Content))
- [x] I have read and accepted the [Terms and Conditions](http://js.org/terms.html)

### Summer break - [subdomain requests won't be processed at the moment](https://github.com/js-org/js.org/issues/4325)
