### PR TITLE
ccknbc.js.org

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -345,6 +345,7 @@ var cnames_active = {
   "catbox": "samsamson33.github.io/catbox.js",
   "cats": "whoisjorge.github.io/not-cat-gifs",
   "cbm": "iamnapo.github.io/cbmjs",
+  "ccknbc": "ccknbc.github.io",
   "cdll": "cdll.github.io",
   "cebu": "javascriptcebu.netlify.com",
   "celery-node": "actumn.github.io/celery.node",


### PR DESCRIPTION
- [x] There is reasonable content on the page (see: [No Content](https://github.com/js-org/js.org/wiki/No-Content))
- [x] I have read and accepted the [Terms and Conditions](http://js.org/terms.html)
Ok, I'm ready, but I still want to use ccknbc.github.io, but he now jumped to ccknbc.js.org, I'm still using vercel, is there a way to make him jump from here? ccknbc- github-io-git-master.ccknbc.vercel.app/