### PR TITLE
whistle.js.org

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -2332,7 +2332,7 @@ var cnames_active = {
   "wglt": "codyebberson.github.io/wglt",
   "wgx": "w-gx.github.io",
   "whadido": "jokester.github.io/whadido",
-  "whistle": "whistle-lang.github.io/whistle",
+  "whistle": "whistle-lang.github.io/website",
   "whiteboard": "yhozen.github.io/whiteboard",
   "wice": "yulioaj290.github.io/wice.js",
   "wii": "andrewplus.github.io/Wii.JS",


### PR DESCRIPTION
Changed the link from whistle-lang.github.io/whistle to whistle-lang.github.io/website

- [x] There is reasonable content on the page (see: [No Content](https://github.com/js-org/js.org/wiki/No-Content))
- [x] I have read and accepted the [Terms and Conditions](http://js.org/terms.html)
