### PR TITLE
upptime.js.org

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -2253,6 +2253,7 @@ var cnames_active = {
   "unsafe": "unsafely.github.io/unsafe.js",
   "up": "codefeathers.github.io/up",
   "uppload": "uppload.netlify.com",
+  "upptime": "koj-co.github.io/upptime",
   "upresent": "bobbybee.github.io/uPresent", // noCF? (don´t add this in a new PR)
   "upset": "upsetjs.github.io",
   "uptime": "intelligo-systems.github.io/uptime.js",


### PR DESCRIPTION
- [x] There is reasonable content on the page (see: [No Content](https://github.com/js-org/js.org/wiki/No-Content))
- [x] I have read and accepted the [Terms and Conditions](http://js.org/terms.html)

From the makers of Uppload (https://uppload.js.org), we're launching Upptime (https://upptime.js.org), a free and open source uptime monitoring and status page template, powered entirely by GitHub Issues, Actions, and Pages.

Suggested labels:

- `add`
- `project`
- `organization`
