### PR TITLE
marked.js.org

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -1257,7 +1257,7 @@ var cnames_active = {
   "markbox": "markbox.netlify.com",
   "markdown-notepad": "jz222.github.io/markdown-notepad",
   "markdownify": "amitmerchant1990.github.io/electron-markdownify",
-  "marked": "markedjs.github.io/marked",
+  "marked": "cname.vercel-dns.com", // noCF
   "markmap": "gera2ld.github.io/markmap-lib",
   "markmsmith": "markmsmith.github.io",
   "markvis": "geekplux.github.io/markvis",


### PR DESCRIPTION
This PR changes marked.js.org from GitHub Pages to Vercel.

## Tasks
- [x] There is reasonable content on the page (see: [No Content](https://github.com/js-org/js.org/wiki/No-Content))
- [x] I have read and accepted the [Terms and Conditions](http://js.org/terms.html)

## Related
- https://github.com/markedjs/marked/pull/1742
- https://github.com/markedjs/marked/pull/1743