### PR TITLE
prismic-nuxt.js.org

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -1651,7 +1651,7 @@ var cnames_active = {
   "pretty-print-json": "center-key.github.io/pretty-print-json",
   "prettylog": "moosecoop.github.io/PrettyLog",
   "prismarine": "prismarinejs.github.io",
-  "prismic-nuxt": "nuxt-community.github.io/prismic-module",
+  "prismic-nuxt": "prismic-module.netlify.app",
   "pristine": "sha256.github.io/Pristine", // noCF
   "producify": "jesobreira.github.io/producify",
   "producthunt-trending": "xiaomingplus.github.io/producthunt-trending",


### PR DESCRIPTION
- [x] There is reasonable content on the page (see: [No Content](https://github.com/js-org/js.org/wiki/No-Content))
- [x] I have read and accepted the [Terms and Conditions](http://js.org/terms.html)

### Information

We're moving from GitHub pages to Netlify, embracing prismic.nuxtjs.org as a new domain for our module's documentation, thanks for providing .js.org as an option for our module's debut!

Related: https://github.com/nuxt-community/prismic-module/pull/93