### PR TITLE
Static mirror of Bootstrap's docs

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -302,6 +302,7 @@ var cnames_active = {
   "bookmarklets": "novadevelopment.github.io/bookmarklets.js",
   "bool": "booljs.github.io",
   "booru": "atlasthebot.github.io/booru",
+  "bootstrap": "https://techboyg5.github.io/bootstrap/",
   "bootstrap-confirmation": "mistic100.github.io/Bootstrap-Confirmation", // noCF? (don´t add this in a new PR)
   "bootstrap-validate": "pascalebeier.github.io/bootstrap-validate",
   "bootstrap-vue": "alias.zeit.co", // noCF


### PR DESCRIPTION
- [x] There is reasonable content on the page (see: [No Content](https://github.com/js-org/js.org/wiki/No-Content))
- [x] I have read and accepted the [Terms and Conditions](http://js.org/terms.html)

Hi there!
This is a static mirror of Bootstrap's docs. I think that it should be added.