### PR TITLE
eon.js.org

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -700,6 +700,7 @@ var cnames_active = {
   "endpoint-imposter": "lukaszmakuch.github.io/endpoint-imposter",
   "energy": "energychain.github.io/energy",
   "engui": "engui.github.io",
+  "eon": "eon-web.github.io/eon",
   "eplayer": "132yse.github.io/eplayer",
   "epoxy": "hosting.gitbook.com",
   "eq8": "eq8.github.io",


### PR DESCRIPTION
Note: The page will not work correctly when viewed from https://eon-web.github.io/eon, because the links on the page assume a root location. By that I mean that a link might point to '/docs' instead of '/eon/docs' because I aim to use a js.org domain

- [x] There is reasonable content on the page (see: [No Content](https://github.com/js-org/js.org/wiki/No-Content))
(My landing page doesn't contain much, most of the interesting stuff is in the docs/docs folder of my repo (markdown in docs/docs/md))
- [x] I have read and accepted the [Terms and Conditions](http://js.org/terms.html)
