### PR TITLE
tsch.js.org

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -2269,6 +2269,7 @@ var cnames_active = {
   "ts-creator": "ts-creator.netlify.com",
   "ts-react-boilerplate": "lapanti.github.io/ts-react-boilerplate",
   "ts2jsdoc": "spatools.github.io/ts2jsdoc", // noCF? (don´t add this in a new PR)
+  "tsc": "type-challenges.netlify.app",
   "tsdi": "knisterpeter.github.io/tsdi",
   "tslib-cli": "hosting.gitbook.com",
   "tslog": "fullstack-build.github.io/tslog",

--- a/cnames_active.js
+++ b/cnames_active.js
@@ -2269,7 +2269,7 @@ var cnames_active = {
   "ts-creator": "ts-creator.netlify.com",
   "ts-react-boilerplate": "lapanti.github.io/ts-react-boilerplate",
   "ts2jsdoc": "spatools.github.io/ts2jsdoc", // noCF? (don´t add this in a new PR)
-  "tsc": "type-challenges.netlify.app",
+  "tsch": "type-challenges.netlify.app",
   "tsdi": "knisterpeter.github.io/tsdi",
   "tslib-cli": "hosting.gitbook.com",
   "tslog": "fullstack-build.github.io/tslog",


### PR DESCRIPTION
- [x] There is reasonable content on the page (see: [No Content](https://github.com/js-org/js.org/wiki/No-Content))
- [x] I have read and accepted the [Terms and Conditions](http://js.org/terms.html)

This site is a bit different from normal use cases, let me explain a bit and hope you found them make sense.

In [this project](https://github.com/type-challenges/type-challenges), we would like to offer a Github-based playground and community for learning type system of TypeScript. So `type-challenges.netlify.app` is actually a bunch of redirecting routes. For example

- `type-challenges.netlify.app` -> will go to our [main Github Repo](https://github.com/type-challenges/type-challenges) (could make a real site for this if it's required)
- `/5` -> will go to the [question #5 's description](https://github.com/type-challenges/type-challenges/blob/master/questions/5-extreme-readonly-keys/README.md)
- `/2/zh-CN` -> will go to the  [question #2 's description in Chinese](https://github.com/type-challenges/type-challenges/blob/master/questions/2-medium-return-type/README.zh-CN.md)
- `/2/play` -> will go to the [**TypeScript playground** with generated question template](https://type-challenges.netlify.app/case/2/play)

The main reason for applying this domain is trying to make an easy and memorizable URL for people to share easily. 
Like [tsc.js.org/5/play](//tsc.js.org/5/play).

I understand this might not fit very well with your rules, but we really want to have a simple and short domain.
Much appreciated! 💖

And let me know if you have better suggestions with the naming.