### PR TITLE
fosspwa.js.org

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -809,6 +809,7 @@ var cnames_active = {
   "formvuelate": "formvuelate.netlify.app",
   "fortnite": "ickerio.github.io/fortnite.js",
   "fortune": "fortunejs.github.io/fortune", // noCF? (don´t add this in a new PR)
+  "fosspwa": "foss-pwa.github.io/app-store",
   "foxford": "netology-group.github.io/foxford.github.io",
   "foxify": "foxifyjs.github.io/foxify",
   "foxman": "kaola-fed.github.io/foxman",


### PR DESCRIPTION
- [x] There is reasonable content on the page (see: [No Content](https://github.com/js-org/js.org/wiki/No-Content))
- [x] I have read and accepted the [Terms and Conditions](http://js.org/terms.html)

Content is in https://wizardly-meitner-61c673.netlify.app because It work only in / of an origin, It is broken currently on github pages.