### PR TITLE
nsw-coronavirus.js.org

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -1541,6 +1541,7 @@ var cnames_active = {
   "npmer": "rumkin.github.io/npm-watch",
   "nsp": "hanul.github.io/NSP", // noCF? (don´t add this in a new PR)
   "nsptiles": "imthenachoman.github.io/nSPTiles", // noCF? (don´t add this in a new PR)
+  "nsw-coronavirus": "maxgherman.github.io/nsw-coronavirus",
   "nuclear": "nukeop.github.io/nuclear",
   "null": "false.netlify.com",
   "numberproto": "vfdan.github.io/NumberProto.js",


### PR DESCRIPTION
Added CNAME entry for "nsw-coronavirus"

- [x] There is reasonable content on the page (see: [No Content](https://github.com/js-org/js.org/wiki/No-Content))
- [x] I have read and accepted the [Terms and Conditions](http://js.org/terms.html)
