### PR TITLE
nodestatus.js.org

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -1531,6 +1531,7 @@ var cnames_active = {
   "nodehawk": "samrith-s.github.io/nodehawk",
   "nodeppt": "ksky521.github.io/nodeppt",
   "noderize": "cretezy.github.io/noderize",
+  "nodestatus": "nodestatus.github.io",
   "noflux": "nofluxjs.gitbooks.io/noflux",
   "nomic": "basicer.github.io/nomic.js-ui",
   "noo": "uyouthe.github.io/noo",


### PR DESCRIPTION
Hey there,
I would like to add `nodestatus.js.org` for a project I am working on called NodeStatus,
as I have just started the project, and I have been super busy with other stuff, I am not able to make the full landing page currently.
I will be able to make the landing page within the next couple of weeks.

- [x] There is reasonable content on the page (see: [No Content](https://github.com/js-org/js.org/wiki/No-Content))
- [x] I have read and accepted the [Terms and Conditions](http://js.org/terms.html)

Thanks,
Joshua Sing (@joshuasing)
