### PR TITLE
suggestcord.js.org

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -2169,6 +2169,7 @@ var cnames_active = {
   "sudarshan": "sudarshanRaul.github.io",
   "sudoku": "andreynering.github.io/sudoku",
   "sug": "opensug.github.io/sug.js.org",
+  "suggestcord": "suggestcord.github.io/docs",
   "suggester": "suggester-bot.github.io/Documentation",
   "suka": "sukkaw.github.io",
   "sulky": "shingle.github.io/sulky", // noCF? (don´t add this in a new PR)


### PR DESCRIPTION
- [x] There is reasonable content on the page (see: [No Content](https://github.com/js-org/js.org/wiki/No-Content))
- [x] I have read and accepted the [Terms and Conditions](http://js.org/terms.html)

Github is already redirecting to suggestcord.js.org, raw content is at https://github.com/Suggestcord/docs/tree/master/docs
