### PR TITLE
Apply NS setup for hx.js.org

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -996,7 +996,6 @@ var cnames_active = {
   "hugorocaproyectos": "hugoroca.github.io/coleccion-proyectos",
   "human": "human-js.gitbooks.io", // noCF? (don´t add this in a new PR)
   "humble": "humblejs.github.io",
-  "hx": "hifocus.github.io/www.hxis.me",
   "hybrids": "hybridsjs.github.io/hybrids",
   "hyde": "gheek.github.io/hyde", // noCF? (don´t add this in a new PR)
   "hydro": "hydro-dev.github.io",

--- a/ns_active.js
+++ b/ns_active.js
@@ -16,6 +16,7 @@
   "appshelf": ["ns31.cloudns.net", "ns32.cloudns.net", "ns33.cloudns.net", "ns34.cloudns.net"],
   "castyte": ["ns31.cloudns.net", "ns32.cloudns.net", "ns33.cloudns.net", "ns34.cloudns.net"],
   "engine262": ["brad.ns.cloudflare.com", "lia.ns.cloudflare.com"],
+  "hx": ["ns1.digitalocean.com.", "ns2.digitalocean.com.", "ns3.digitalocean.com."],
   "lolifamily": ["glen.ns.cloudflare.com","melany.ns.cloudflare.com"],
   "ruby": ["alexis.ns.cloudflare.com", "connie.ns.cloudflare.com"],
   "samplasion": ["ns31.cloudns.net", "ns32.cloudns.net", "ns33.cloudns.net", "ns34.cloudns.net"],


### PR DESCRIPTION
- [x] There is reasonable content on the page (see: [No Content](https://github.com/js-org/js.org/wiki/No-Content))
- [x] I have read and accepted the [Terms and Conditions](http://js.org/terms.html)

Hi. This PR is intending to convert the CNAME setup for the original hx.js.org to a NS setup.

----
The reason behind this:

Recently my open source project get.js.org encountered the issue that a http javascript redirection from the https page of the project will be denied by Chrome because of mixed-content, which should be something that was recently changed. My idea to resolve the problem is that to use server-side redirection for the https 2 http redirect. So like https://get.js.org/potplayer 's download cannot be proceed because the latest Chrome blocked the http download request.

Since get.js.org is an open source project, all resources it use must have reasonably high availibility. So I would much rather to not to host such redirection service / domain on my own domains or servers.

By converting hx.js.org to a NS setup, not only hx.js.org itself as my personal homepage can keep its appearence instead of getting redirected to hxis.me, by using Netlify's multi-domain setup, which GitHub Pages doesn't support, but also I can create sub-subdomains like `get-redirect.js.org` then link the domain to Netlify or Vercel, to setup the sever-side redirection serverless-ly. In this way, both the domain and the service remained operated by reliable third-parties, so that even in the event of all my servers / domains are down, the open source project can keep its operation and continue to service people.

I sincerely hope this can be approved. Thank you for your kind support.