### PR TITLE
upptime.js.org

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -2394,7 +2394,7 @@ var cnames_active = {
   "unsafe": "unsafely.github.io/unsafe.js",
   "up": "codefeathers.github.io/up",
   "uppload": "uppload.netlify.com",
-  "upptime": "koj-co.github.io/upptime",
+  "upptime": "upptime.github.io",
   "upresent": "bobbybee.github.io/uPresent", // noCF? (don´t add this in a new PR)
   "upset": "upsetjs.github.io",
   "uptime": "intelligo-systems.github.io/uptime.js",


### PR DESCRIPTION
Hello! We've moved our repository https://github.com/upptime/upptime to its own GitHub organization, and would love the CNAME to reflect the new URL.

As proof of the move, you can visit the previous URL https://github.com/koj-co/upptime and it will redirect you to the new one. Thanks!

- [x] There is reasonable content on the page (see: [No Content](https://github.com/js-org/js.org/wiki/No-Content))
- [x] I have read and accepted the [Terms and Conditions](http://js.org/terms.html)
