### PR TITLE
sql.js.org

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -2163,6 +2163,7 @@ var cnames_active = {
   "spring": "hosting.gitbook.com",
   "spritesheet": "arcadiogarcia.github.io/Spritesheet.js", // noCF? (don´t add this in a new PR)
   "spritewerk": "bildepunkt.github.io/spritewerk", // noCF? (don´t add this in a new PR)
+  "sql": "sql-js.github.io/sql.js",
   "sqrvival": "sawyerjs.github.io/sqrvival",
   "squeak": "bertfreudenberg.github.io/SqueakJS",
   "squirrelly": "squirrellyjs.netlify.com", // noCF


### PR DESCRIPTION
Add sql.js

See https://github.com/js-org/js.org/issues/3775 for the discussion about sql-js.js.org vs sql.js.org

See the current rendered website on http://sql-js.github.io/sql.js/
See [the PR to add the CNAME](https://github.com/sql-js/sql.js/pull/428) (it will be merged immediately after the new cname is available)

- [x] There is reasonable content on the page (see: [No Content](https://github.com/js-org/js.org/wiki/No-Content))
- [x] I have read and accepted the [Terms and Conditions](http://js.org/terms.html)
