### PR TITLE
hx.js.org

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -999,7 +999,7 @@ var cnames_active = {
   "hugorocaproyectos": "hugoroca.github.io/coleccion-proyectos",
   "human": "human-js.gitbooks.io", // noCF? (don´t add this in a new PR)
   "humble": "humblejs.github.io",
-  "hx": "hifocus.github.io/www.hxis.me",
+  "hx": "hx-js-org.d53923.flexbalancer.net",
   "hybrids": "hybridsjs.github.io/hybrids",
   "hyde": "gheek.github.io/hyde", // noCF? (don´t add this in a new PR)
   "hydro": "hydro-dev.github.io",


### PR DESCRIPTION
- [x] There is reasonable content on the page (see: [No Content](https://github.com/js-org/js.org/wiki/No-Content))
- [x] I have read and accepted the [Terms and Conditions](http://js.org/terms.html)

I would like to modify the cname record on hx.js.org to a load-balancing service, so that I can add downtime fallbacks and change the direction of the site again without hassling the js.org team.

Also by having this update, the hx.js.org domain will have its own interface, instead of getting redirected to third-party sites, which I have just recently learnt it's not permitted.