### PR TITLE
klisi.js.org

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -1190,6 +1190,7 @@ var cnames_active = {
   "klasy-eris": "motiontheking.github.io/klasy-eris",
   "klepto": "mwjaworski.github.io/klepto",
   "klick": "hosting.gitbook.com",
+  "klisi": "cfanoulis.github.io/klisi.ts",
   "kmeans": "jeff-tian.github.io/k-means",
   "knacss-vue": "arnissolle.github.io/knacss-vue",
   "knc": "chaituknag.github.io",


### PR DESCRIPTION
Just drafting this PR before I make sure documentation CD is all-ok

I wish to reserve the `klisi` subdomain (means `conjugation` in Greek for my library named `klisi`, which provides utilities to conjugate Greek names

- [ ] There is reasonable content on the page (see: [No Content](https://github.com/js-org/js.org/wiki/No-Content))
- [x] I have read and accepted the [Terms and Conditions](http://js.org/terms.html)
