### PR TITLE
lucia.js.org

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -1317,7 +1317,7 @@ var cnames_active = {
   "lps": "mauris.github.io/lps.js.org",
   "lribeiro": "lmribeiro.github.io",
   "ls": "links-js.github.io",
-  "lucia": "aidenybai.github.io/lucia",
+  "lucia": "lucia.netlify.app",
   "lucy": "lucy-bot.github.io",
   "luis": "luiscloud.github.io",
   "lukks": "lukks.github.io/page",


### PR DESCRIPTION
Changed from gh pages to [Netlify](https://lucia.netlify.app/) for new docs
- [x] There is reasonable content on the page (see: [No Content](https://github.com/js-org/js.org/wiki/No-Content))
- [x] I have read and accepted the [Terms and Conditions](http://js.org/terms.html)
