### PR TITLE
isbot.js.org

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -1084,7 +1084,7 @@ var cnames_active = {
   "iro": "jaames.github.io/iro.js",
   "irouter": "alhaqhassan.github.io/irouter.js",
   "is": "arasatasaygin.github.io/is.js", // noCF? (don´t add this in a new PR)
-  "isbot": "gorangajic.github.io/isbot",
+  "isbot": "omrilotan.github.io/isbot",
   "iscaptive": "marvnet.github.io/iscaptive",
   "isfa": "isfaaghyth.github.io",
   "ishan": "ishanthukral.github.io/ishan.js", // noCF? (don´t add this in a new PR)


### PR DESCRIPTION
Repository was transferred

```
>>> https://github.com/gorangajic/isbot

> --------------------------------------------
> 301 Moved Permanently
> --------------------------------------------
Code:	301
content-type:	text/html; charset=utf-8
server:	GitHub.com
status:	301 Moved Permanently
Location:	https://github.com/omrilotan/isbot
```

- [x] There is reasonable content on the page (see: [No Content](https://github.com/js-org/js.org/wiki/No-Content))
- [x] I have read and accepted the [Terms and Conditions](http://js.org/terms.html)
