### PR TITLE
upptime.js.org

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -2438,7 +2438,7 @@ var cnames_active = {
   "unsafe": "unsafely.github.io/unsafe.js",
   "up": "codefeathers.github.io/up",
   "uppload": "uppload.netlify.com",
-  "upptime": "upptime.github.io",
+  "upptime": "upptime.github.io/upptime.js.org",
   "upresent": "bobbybee.github.io/uPresent", // noCF? (don´t add this in a new PR)
   "upset": "upsetjs.github.io",
   "uptime": "intelligo-systems.github.io/uptime.js",


### PR DESCRIPTION
In this PR, I'm changing the CNAME for upptime.js.org from `upptime.github.io ` to `upptime.github.io/upptime.js.org`. This is because we've built a new static website at https://github.com/upptime/upptime.js.org.

Our new website (with CNAME already added) is available here: https://github.com/upptime/upptime.js.org/tree/gh-pages. As you'll notice, I'm the representative who first added upptime to js.org in #4488 and then updated it in #4778.

- [x] There is reasonable content on the page (see: [No Content](https://github.com/js-org/js.org/wiki/No-Content))
- [x] I have read and accepted the [Terms and Conditions](http://js.org/terms.html)
