### PR TITLE
demo.upptime.js.org

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -2444,7 +2444,7 @@ var cnames_active = {
   "up": "codefeathers.github.io/up",
   "uppload": "uppload.netlify.com",
   "upptime": "upptime.github.io/upptime.js.org",
-  "demo.upptime": "upptime.github.io/upptime",
+  "demo.upptime": "upptime.github.io/upptime", // noCF
   "upresent": "bobbybee.github.io/uPresent", // noCF? (don´t add this in a new PR)
   "upset": "upsetjs.github.io",
   "uptime": "intelligo-systems.github.io/uptime.js",

--- a/cnames_active.js
+++ b/cnames_active.js
@@ -2444,6 +2444,7 @@ var cnames_active = {
   "up": "codefeathers.github.io/up",
   "uppload": "uppload.netlify.com",
   "upptime": "upptime.github.io/upptime.js.org",
+  "demo.upptime": "upptime.github.io/upptime",
   "upresent": "bobbybee.github.io/uPresent", // noCF? (don´t add this in a new PR)
   "upset": "upsetjs.github.io",
   "uptime": "intelligo-systems.github.io/uptime.js",


### PR DESCRIPTION
**Request:**

I want a second-level subdomain. We already have https://upptime.js.org, but want to add a demo status page on https://demo.upptime.js.org. I know that Cloudflare natively supports this, so adding the CNAME record for `demo.upptime.js.org.` should work just as `upptime.js.org.` does.

The CNAME has already been added in the project: https://github.com/upptime/upptime/tree/gh-pages and the file is https://github.com/upptime/upptime/blob/gh-pages/CNAME.

If you're unable to accept this PR, I can use a different top-level subdomain, such as https://upptime-demo.js.org instead.

**Related PRs:**

- #4488

**Checks:**

- [x] There is reasonable content on the page (see: [No Content](https://github.com/js-org/js.org/wiki/No-Content))
- [x] I have read and accepted the [Terms and Conditions](http://js.org/terms.html)
