### PR TITLE
flameshot.js.org

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -827,7 +827,6 @@ var cnames_active = {
   "fireorm": "wovalle.github.io/fireorm",
   "five": "jackdcrawford.github.io/five",
   "flamecord": "flamexode.github.io/flamecord",
-  "flameshot": "flameshot-org.github.io",
   "flap": "slurmulon.github.io/flap",
   "flash": "flashcardjs.github.io",
   "flatpickr": "flatpickr.github.io",


### PR DESCRIPTION
* Now flameshot project domain is moved to flameshot.org

- [x] There is reasonable content on the page (see: [No Content](https://github.com/js-org/js.org/wiki/No-Content))
- [x] I have read and accepted the [Terms and Conditions](http://js.org/terms.html)
