### PR TITLE
discordapi.js.org

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -609,6 +609,7 @@ var cnames_active = {
   "dinos": "0xflotus.github.io/dinos",
   "discodo": "sirubot.github.io/discodo.js",
   "discord": "discordjs.github.io/website",
+  "discordapi": "dscapi.github.io",
   "discord-anti-spam": "michael-j-scofield.github.io/discord-anti-spam",
   "discord-bio": "assfugil.github.io/discord.bio",
   "discord-extras": "documentation-html-template.onyx6227.repl.co",


### PR DESCRIPTION
- [x] There is reasonable content on the page (see: [No Content](https://github.com/js-org/js.org/wiki/No-Content))
- [x] I have read and accepted the [Terms and Conditions](http://js.org/terms.html)
I redirected discordapi.js.org as a private domain to the dscapi.github.io domain. //translate (I want to create a new domain in short.)
I have read and accept.
