### PR TITLE
react-native-elements.js.org

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -1903,6 +1903,7 @@ var cnames_active = {
   "react-layout-components": "kripod.github.io/react-layout-components",
   "react-leaflet": "paullecam.github.io/react-leaflet",
   "react-move": "react-move.netlify.com",
+  "react-native-elements": "react-native-elements.github.io/playground",
   "react-native-floating-labels": "mayank-patel.github.io/react-native-floating-labels",
   "react-native-track-player": "react-native-kit.github.io/react-native-track-player", // noCF
   "react-observatory": "hosting.gitbook.com",


### PR DESCRIPTION
Added react-native-elements.js.org

https://react-native-elements.github.io/playground/#/

- [x] There is reasonable content on the page (see: [No Content](https://github.com/js-org/js.org/wiki/No-Content))
- [x] I have read and accepted the [Terms and Conditions](http://js.org/terms.html)
