### PR TITLE
dbots.js.org

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -577,7 +577,7 @@ var cnames_active = {
   "dblog": "dblog.netlify.com",
   "dbo": "z3ta.github.io/dbo", // noCF? (don´t add this in a new PR)
   "dbothook": "dbots-pkg.github.io/dbothook-website",
-  "dbots": "dbots-pkg.github.io",
+  "dbots": "dbots-pkg.github.io/dbots-website",
   "dbt": "aakhilv.github.io/dbt",
   "deck-of-cards": "pakastin.github.io/deck-of-cards",
   "declarativ": "fennifith.github.io/declarativ", // noCF


### PR DESCRIPTION
Hi, we moved our organization website to a project website.
At the moment, the https://dbots.js.org/ URL seems to work fine, but I think it's better if we update it, hoping it won't mess up with how GitHub pages is currently deploying...