### PR TITLE
mocha1995.js.org

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -1534,6 +1534,7 @@ var cnames_active = {
   "mobx-keystone": "mobx-keystone.netlify.com",
   "mobx-react": "mobx-react.netlify.com",
   "mobx-state-tree": "mobxjs.github.io/mobx-state-tree",
+  "mocha1995": "doodlewind.github.io/mocha1995",
   "mock-cmdr": "ncjones.github.io/mock-cmdr",
   "mock-middleware": "luobotang.github.io/mock-middleware",
   "mockjs-lite": "52cik.github.io/mockjs-lite", // noCF


### PR DESCRIPTION
This PR links to online version of the first JavaScript engine Mocha written in 1995, compiled back to WASM and JavaScript.

- [x] There is reasonable content on the page (see: [No Content](https://github.com/js-org/js.org/wiki/No-Content))
- [x] I have read and accepted the [Terms and Conditions](http://js.org/terms.html)

Current content on the gh-pages branch: https://github.com/doodlewind/mocha1995/tree/gh-pages
