### PR TITLE
somerandomcat.js.org

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -2296,6 +2296,7 @@ var cnames_active = {
   "sogou": "iguanren.github.io/sogou",
   "solder": "mcrocks999.github.io/solder.js",
   "solome": "solome.github.io",
+  "somerandomcat": "hosting.gitbook.io", // noCF
   "soniq": "fullstack-build.github.io/soniq",
   "sonny": "sonnylazuardi.github.io", // noCF? (don´t add this in a new PR)
   "soofik": "soofik.github.io",


### PR DESCRIPTION
- [x] There is reasonable content on the page (see: [No Content](https://github.com/js-org/js.org/wiki/No-Content))
- [x] I have read and accepted the [Terms and Conditions](http://js.org/terms.html)

Hi there, 
With reference to our talk in #5110, It seems like it was a bug on gitbook's end. They said that they can help us skip that dialog. It is also preferred to disable cloudfare proxying on it. The [CNAME](https://docs.gitbook.com/hosting/custom-domains/dns-configuration#cname-record) has to be done like that. Waiting for your reply..
Thankyou
