### PR TITLE
artalk.js.org

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -193,7 +193,7 @@ var cnames_active = {
   "arime": "ninbryan.github.io/arime", // noCF? (don´t add this in a new PR)
   "arithmy": "arithmy.netlify.app",
   "arshad": "arshadmhabib.github.io",
-  "artalk": "qwqcode.github.io/Artalk",
+  "artalk": "cname.vercel-dns.com",
   "artery": "arteryjs.github.io/gh-pages", // noCF? (don´t add this in a new PR)
   "arthurmbandeira": "arthurmbandeira.github.io",
   "artitalk": "artitalkjs.github.io/docs",


### PR DESCRIPTION
## Update ArtalkJS cname

- [x] There is reasonable content on the page (see: [No Content](https://github.com/js-org/js.org/wiki/No-Content))
- [x] I have read and accepted the [Terms and Conditions](http://js.org/terms.html)

Hi there!

This PR for changing `artalk.js.org` from GitHub Pages to Vercel.

https://github.com/ArtalkJS/Artalk

Would be super cool to get this updated.
Thanks a lot!

😆