### PR TITLE
mike.js.org

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -1541,6 +1541,7 @@ var cnames_active = {
   "middy": "plnt9.github.io/middy",
   "miguelsr": "miguelsr.github.io", // noCF? (don´t add this in a new PR)
   "mikado": "nextapps-de.github.io/mikado",
+  "mike": "mikebars.github.io",
   "milesgitgud": "milesgitgud.github.io/homepage",
   "militia": "militia21.github.io/militia",
   "militia21": "militia21.github.io/militia21",


### PR DESCRIPTION
Content at https://mikebars.github.io/ (temporarily down while CNAME file with mike.js.org present)
Content repo: https://github.com/mikebars/mikebars.github.io

- [x] There is reasonable content on the page (see: [No Content](https://github.com/js-org/js.org/wiki/No-Content))
- [x] I have read and accepted the [Terms and Conditions](http://js.org/terms.html)
