### PR TITLE
risingstars.js.org

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -2135,7 +2135,7 @@ var cnames_active = {
   "riot": "riot.github.io",
   "riotgear": "riotgear.github.io",
   "rishi": "rishiosaur.github.io",
-  "risingstars": "risingstars.netlify.com",
+  "risingstars": "cname.vercel-dns.com",
   "risingstars2016": "michaelrambeau.github.io/risingstars2016",
   "rize": "g-plane.github.io/rize",
   "rmodal": "zewish.github.io/rmodal.js",


### PR DESCRIPTION
Hello Stefan and all other members of the `js.org` community!

I run _Best of JS_ application and _JavaScript Rising Stars_ the annual round-up about the landscape.

For the 2020 edition, we move the application from Netlify to Vercel.

Here is the draft: https://javascript-risingstars.vercel.app/

Could you update the CNAME file?

Thank you in advance!

![image](https://user-images.githubusercontent.com/5546996/104178477-bcb31500-544d-11eb-9339-08b8e136cc39.png)

- [x] There is reasonable content on the page (see: [No Content](https://github.com/js-org/js.org/wiki/No-Content))
- [x] I have read and accepted the [Terms and Conditions](http://js.org/terms.html)
