### PR TITLE
novasheets.js.org

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -1735,7 +1735,7 @@ var cnames_active = {
   "notepad": "amitmerchant1990.github.io/notepad",
   "nothing": "cbtak.github.io/nothing",
   "notibar": "duyetdev.github.io/notibar.js",
-  "novasheets": "novasheets.github.io/website",
+  "novasheets": "novasheets.netlify.app",
   "npkill": "voidcosmos.github.io/npkill",
   "npmer": "rumkin.github.io/npm-watch",
   "nsp": "hanul.github.io/NSP", // noCF? (don´t add this in a new PR)


### PR DESCRIPTION
Point to Netlify instead of GitHub.io

Repo: @NovaSheets/website
Hosted at https://novasheets.netlify.app

Was added in #5385

- [x] There is reasonable content on the page (see: [No Content](https://github.com/js-org/js.org/wiki/No-Content))
- [x] I have read and accepted the [Terms and Conditions](http://js.org/terms.html)
