### PR TITLE
dev-panel.js.org

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -629,7 +629,7 @@ var cnames_active = {
   "developerfolio": "saadpasta.github.io/developerFolio",
   "devilapi": "devilapi.kazult.repl.co",
   "devilowl": "website.kazult.repl.co",
-  "dev-panel": "https://github.com/Involve-Digital/dev-panel",
+  "dev-panel": "Involve-Digital.github.io/dev-panel",
   "devsession": "lukasbach.github.io/devsession",
   "devtr": "zmorcy.github.io/devtr.github.io",
   "dgelong": "alexeyraspopov.github.io/dgelong", // noCF? (don´t add this in a new PR)

--- a/cnames_active.js
+++ b/cnames_active.js
@@ -629,6 +629,7 @@ var cnames_active = {
   "developerfolio": "saadpasta.github.io/developerFolio",
   "devilapi": "devilapi.kazult.repl.co",
   "devilowl": "website.kazult.repl.co",
+  "dev-panel": "https://github.com/Involve-Digital/dev-panel",
   "devsession": "lukasbach.github.io/devsession",
   "devtr": "zmorcy.github.io/devtr.github.io",
   "dgelong": "alexeyraspopov.github.io/dgelong", // noCF? (don´t add this in a new PR)

--- a/cnames_active.js
+++ b/cnames_active.js
@@ -629,7 +629,7 @@ var cnames_active = {
   "developerfolio": "saadpasta.github.io/developerFolio",
   "devilapi": "devilapi.kazult.repl.co",
   "devilowl": "website.kazult.repl.co",
-  "dev-panel": "https://github.com/Involve-Digital/dev-panel", //test
+  "dev-panel": "https://github.com/Involve-Digital/dev-panel",
   "devsession": "lukasbach.github.io/devsession",
   "devtr": "zmorcy.github.io/devtr.github.io",
   "dgelong": "alexeyraspopov.github.io/dgelong", // noCF? (don´t add this in a new PR)

--- a/cnames_active.js
+++ b/cnames_active.js
@@ -629,7 +629,7 @@ var cnames_active = {
   "developerfolio": "saadpasta.github.io/developerFolio",
   "devilapi": "devilapi.kazult.repl.co",
   "devilowl": "website.kazult.repl.co",
-  "dev-panel": "https://github.com/Involve-Digital/dev-panel",
+  "dev-panel": "https://github.com/Involve-Digital/dev-panel", //test
   "devsession": "lukasbach.github.io/devsession",
   "devtr": "zmorcy.github.io/devtr.github.io",
   "dgelong": "alexeyraspopov.github.io/dgelong", // noCF? (don´t add this in a new PR)


### PR DESCRIPTION
- [x] There is reasonable content on the page (see: [No Content](https://github.com/js-org/js.org/wiki/No-Content))
- [x] I have read and accepted the [Terms and Conditions](http://js.org/terms.html)

Hi, I'd love to publish docsify documentation of upcoming release of project called dev-panel. Please have a look here: https://involve-digital.github.io/dev-panel/#/

Repo: https://github.com/Involve-Digital/dev-panel
Documentation is in directory: /docs
CNAME file is in: https://github.com/Involve-Digital/dev-panel/tree/gh-pages

It'd be great, if URL could be dev-panel.js.org as it sounds quite nice :)
Thanks a lot, Ondřej Tölg.