### PR TITLE
Add a GitHub action to validate js files

### DIFF
--- a/.github/workflows/lint.js.yml
+++ b/.github/workflows/lint.js.yml
@@ -1,0 +1,26 @@
+name: Lint js files
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Use Node.js 14.x
+      uses: actions/setup-node@v1
+      with:
+        node-version: 14.x
+    - name: Lint
+      uses: github/super-linter@v3
+      env:
+        VALIDATE_ALL_CODEBASE: true
+        VALIDATE_JAVASCRIPT_ES: true
+        DEFAULT_BRANCH: master
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/cnames_active.js
+++ b/cnames_active.js
@@ -2467,7 +2467,7 @@ var cnames_active = {
   "synergy": "synergyaddons.github.io/synergy-addons",
   "synth": "lukehorvat.github.io/synth-mood",
   "syr": "dmikey.github.io/syr",
-  "smartestchatbot": "lebyy.github.io/smartestchatbotdocs".
+  "smartestchatbot": "lebyy.github.io/smartestchatbotdocs",
   "t": "l-js.mydevapp.tfuture.eu.org", // noCF
   "tab": "gdmcc.github.io/tab",
   "tagster": "goschevski.github.io/tagster", // noCF? (don´t add this in a new PR)


### PR DESCRIPTION
Manually edits are error-prone, one can easily introduce a typo (such as `.` instead of `,`). This PR adds a GitHub action which runs eslint via GitHub super-linter to validate javascript files in the pulls requests and pushes to master branch.
Once there is an error in a file, the check would fail and there would be a message in the logs of the action indicating what kind of error happened and where.
- [x] I have read and accepted the [Terms and Conditions](http://js.org/terms.html)

There's an exmpole run in my fork: https://github.com/cy6erskunk/js.org/pull/1
I believe the action is not executed in this PR beacuse it's an action from a fork and it's not gonna work before it's merged.