### PR TITLE
noflux.js.org

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -1727,7 +1727,7 @@ var cnames_active = {
   "nodehawk": "samrith-s.github.io/nodehawk",
   "nodeppt": "ksky521.github.io/nodeppt",
   "noderize": "cretezy.github.io/noderize",
-  "noflux": "nofluxjs.gitbooks.io/noflux",
+  "noflux": "hosting.gitbook.io", // noCF
   "nomic": "basicer.github.io/nomic.js-ui",
   "noo": "uyouthe.github.io/noo",
   "noobscroll": "arguiot.github.io/NoobScroll",


### PR DESCRIPTION
noflux.js.org is hosted on Gitbook, I create this PR because of this issue https://github.com/js-org/js.org/issues/5407

- [x] There is reasonable content on the page (see: [No Content](https://github.com/js-org/js.org/wiki/No-Content))
- [x] I have read and accepted the [Terms and Conditions](http://js.org/terms.html)
