### PR TITLE
godzm4tt3o.js.org

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -1001,7 +1001,6 @@ var cnames_active = {
   "glottologist": "arguiot.github.io/Glottologist",
   "gnatale": "giosooul.github.io/gnatale.github.io",
   "god": "godow.github.io",
-  "godzm4tt3o": "godzm4tt3o.github.io",
   "gogs": "rpgjw54g31k5yd4q.preview.edgeapp.net",
   "goji": "airbnb.github.io/goji-js",
   "gol": "goljs.github.io/GoL",


### PR DESCRIPTION
The "godzm4tt3o" subdomain was for personal use, now I have my own domain, so "godzm4tt3o.js.org" is now useless, and should be removed.

- [x] There is reasonable content on the page (see: [No Content](https://github.com/js-org/js.org/wiki/No-Content))
- [x] I have read and accepted the [Terms and Conditions](http://js.org/terms.html)
