### PR TITLE
smart-text-editor.js.org

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -2217,7 +2217,6 @@ var cnames_active = {
   "slidey": "thegreatrazz.github.io/slidey",
   "slim": "eavichay.github.io/slim.js",
   "slinky": "alizahid.github.io/slinky",
-  "smart-text-editor": "smart-text-editor-official.github.io/ste",
   "smartquotes": "kellym.github.io/smartquotes.js",
   "smiley": "Smiley422.github.io",
   "smoke": "hxgf.github.io/smoke",


### PR DESCRIPTION
The GitHub Pages site for our Smart Text Editor project no longer needs a custom domain, and the GitHub organization has been taken down as well.

- [x] There is reasonable content on the page (see: [No Content](https://github.com/js-org/js.org/wiki/No-Content))
- [x] I have read and accepted the [Terms and Conditions](http://js.org/terms.html)
