### PR TITLE
chainson.js.org

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -409,6 +409,7 @@ var cnames_active = {
   "ceyhun": "ceyhunmelek.github.io/ceyhun",
   "cgoatone": "cgoatone.github.io",
   "chain-able": "fluents.github.io/chain-able-site",
+  "chainson": "abcdan.github.io/chainson",
   "chameleon": "glitch.edgeapp.net",
   "chandzhang": "chandzhang.github.io",
   "charge": "charge-js.netlify.com",


### PR DESCRIPTION
- [x] There is reasonable content on the page (see: [https://abcdan.github.io/chainson](https://abcdan.github.io/chainson)) _CNAME already there and forwarding sadly. It uses Github pages their default theme and also hosts the automatically generated documentation over at /docs/index.html_
- [x] I have read and accepted the [Terms and Conditions](http://js.org/terms.html)

Here's my PR, Have an amazing day!