### PR TITLE
8085sim.js.org

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -54,6 +54,7 @@ var cnames_active = {
   "404": "licshee.github.io/404",
   "766": "766.github.io",
   "7anshuai": "7anshuai.github.io", // noCF? (don´t add this in a new PR)
+  "8085sim": "ahmedazhar05.github.io/8085sim",
   "8log": "8log.netlify.app",
   "98": "1j01.github.io/98",
   "9932": "dannyzhan.github.io",


### PR DESCRIPTION
The web app is completely based on vanilla js, hence a perfect fit for a js.org subdomain. Thanks

- [x] I have read and accepted the [Terms and Conditions](http://js.org/terms.html)
- [x] There is reasonable content on the page
- [x] I have added a CNAME file to my repo: [github.com/ahmedazhar05/8085sim](https://github.com/ahmedazhar05/8085sim)