### PR TITLE
cordis.js.org

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -509,6 +509,7 @@ var cnames_active = {
   "coord": "itsacorn.github.io/jscoord",
   "copyer": "tsycode.github.io/copyer.js",
   "copywriting-correct": "rikakomoe.github.io/copywriting-correct",
+  "cordis": "cordis-lib.github.io",
   "cordova-multiplatform-template": "ckgrafico.github.io/Cordova-Multiplatform-Template", // noCF? (don´t add this in a new PR)
   "coreact": "coreactjs.github.io/coreact",
   "coredi": "empla.github.io/coredi",


### PR DESCRIPTION
- [x] There is reasonable content on the page (see: [No Content](https://github.com/js-org/js.org/wiki/No-Content))
- [x] I have read and accepted the [Terms and Conditions](http://js.org/terms.html)

Cordis is a micro-service based toolset for working with Discord's API. The current implementation is done in lovely TypeScript and there's no plan to move away from it, standing as a JS project.

I would like to host the documentation for it on `cordis.js.org`.

The CNAME file is automatically written by CI, I would prefer updating it after this pull request is merged, but if I have to do it before-hand, please let me know.