### PR TITLE
cleaners.js.org

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -454,6 +454,7 @@ var cnames_active = {
   "classroom": "epoxydevelopment.github.io/Classroom",
   "clause": "clausejs.github.io/clausejs",
   "cleanblog": "cleanblog.github.io",
+  "cleaners": "swansontec.github.io/cleaners",
   "clearlyelevated": "clearlyelevated.github.io",
   "clevercord": "theanidox.github.io/Clevercord",
   "clickforhelp": "clickforhelp.netlify.app",


### PR DESCRIPTION
The cleaners library on NPM / Deno is finally getting a documentation website, so it would be nice to have a slick URL.

You can see the site at the following branch: https://github.com/swansontec/cleaners/tree/william/docsify/docs

- [x] There is reasonable content on the page (see: [No Content](https://github.com/js-org/js.org/wiki/No-Content))
- [x] I have read and accepted the [Terms and Conditions](http://js.org/terms.html)
