### PR TITLE
vademecum-rrg.js.org

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -2625,6 +2625,7 @@ var cnames_active = {
   "v4.webpack": "webpack.github.io/v4.webpack.js.org", // noCF
   "v4f": "v4f.netlify.com",
   "vac": "mlinquan.github.io/vue-awesome-countdown",
+  "vademecum-rrg": "ruxo-rod.github.io/portafolio",
   "vagus": "thevagus.github.io",
   "valence-native": "valence-native.github.io/valence-native",
   "valentin": "valentinvieriu.github.io", // noCF? (don´t add this in a new PR)


### PR DESCRIPTION
add line 2628   "vademecum-rrg": "ruxo-rod.github.io/portafolio",

- [x] There is reasonable content on the page (see: [No Content](https://github.com/js-org/js.org/wiki/No-Content))
- [x] I have read and accepted the [Terms and Conditions](http://js.org/terms.html)
