### PR TITLE
Add register.js.org to domain list

### DIFF
--- a/records_restricted.js
+++ b/records_restricted.js
@@ -184,6 +184,7 @@ var cnames_restricted = [
     "raw",
     "readme(s)",
     "regex(p)",
+    "regist(er/ration/ered)",
     "remote",
     "require",
     "rest",


### PR DESCRIPTION
I think that register.js.org shouldn't be available. Not to mention you guys are keeping ones that are way more obscure, like regex.js.org? So I think that register.js.org should be added.

- [ ] There is reasonable content on the page (see: [No Content](https://github.com/js-org/js.org/wiki/No-Content))
^^ Does this apply?
- [x] I have read and accepted the [Terms and Conditions](http://js.org/terms.html)
