### PR TITLE
npmgraph.js.org

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -1725,7 +1725,7 @@ var cnames_active = {
   "npkill": "voidcosmos.github.io/npkill",
   "nplayer": "woopen.github.io/nplayer",
   "npmer": "rumkin.github.io/npm-watch",
-  "npmgraph": "npmgraph.github.io",
+  "npmgraph": "cname.vercel-dns.com",
   "nsp": "hanul.github.io/NSP", // noCF? (don´t add this in a new PR)
   "nsptiles": "imthenachoman.github.io/nSPTiles", // noCF? (don´t add this in a new PR)
   "nsw-coronavirus": "maxgherman.github.io/nsw-coronavirus",

--- a/cnames_active.js
+++ b/cnames_active.js
@@ -1725,7 +1725,7 @@ var cnames_active = {
   "npkill": "voidcosmos.github.io/npkill",
   "nplayer": "woopen.github.io/nplayer",
   "npmer": "rumkin.github.io/npm-watch",
-  "npmgraph": "cname.vercel-dns.com",
+  "npmgraph": "cname.vercel-dns.com",  // noCF
   "nsp": "hanul.github.io/NSP", // noCF? (don´t add this in a new PR)
   "nsptiles": "imthenachoman.github.io/nSPTiles", // noCF? (don´t add this in a new PR)
   "nsw-coronavirus": "maxgherman.github.io/nsw-coronavirus",


### PR DESCRIPTION
It looks like most of the other Vercel-hosted domains here use `// noCF`.  Do we want/need that?

cc: @fregante

- [x] There is reasonable content on the page (see: [No Content](https://github.com/js-org/js.org/wiki/No-Content))
- [x] I have read and accepted the [Terms and Conditions](http://js.org/terms.html)
