### PR TITLE
zykj.js.org

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -2884,7 +2884,7 @@ var cnames_active = {
   "zty": "zetaoyang.github.io",
   "zxy": "ZXYFrank.github.io",
   "zyh": "zyh-chopper.github.io/zyh",
-  "zykj": "zykj.now.sh", // noCF
+  "zykj": "cname.vercel-dns.com", // noCF
   "zyy": "zyyou.github.io/notes"
   /*
    * please don't add your subdomain records down here!


### PR DESCRIPTION
- [x] There is reasonable content on the page (see: [No Content](https://github.com/js-org/js.org/wiki/No-Content))
- [x] I have read and accepted the [Terms and Conditions](http://js.org/terms.html)
New "now.sh" domains are deprecated. Use "vercel.app" instead.