### PR TITLE
krowa.js.org

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -1333,7 +1333,6 @@ var cnames_active = {
   "kowalski": "k0walslk1.github.io",
   "kra": "kra-framework.github.io/kra-suite", // noCF
   "kremling": "canopytax.github.io/kremling.js.org",
-  "krowa": "colenh.github.io/krowa",
   "kshitij": "kshitij98.github.io",
   "ksp": "keepsobp.github.io",
   "kst": "lucaelin.github.io/KST", // noCF


### PR DESCRIPTION
An amendment to https://github.com/js-org/js.org/pull/5988. 
I have sunset the Krowa project and NPM package and I will no longer be utilizing this subdomain.

- [x] I have read and accepted the Terms and Conditions
