### PR TITLE
chromatography.js.org

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -452,7 +452,7 @@ var cnames_active = {
   "chrismendis": "chrismendis.github.io", // noCF? (don´t add this in a new PR)
   "christo": "christoga.github.io/js-org", // noCF? (don´t add this in a new PR)
   "christopher": "marekkobida.github.io/christopher",
-  "chromatography": "teamtofu.github.io/chromatography",
+  "chromatography": "catalent.github.io/chromatography",
   "chronos": "espinielli.github.io/chronos", // noCF? (don´t add this in a new PR)
   "ciphercrack": "avirut.github.io/ciphercrack",
   "citation": "citation-js.github.io/site",


### PR DESCRIPTION
Switched from personal to work ownership for repo. [github.com/teamtofu/chromatography](https://github.com/teamtofu/chromatography) now redirects to [github.com/catalent/chromatography](https://github.com/catalent/chromatography) due to an ownership change.

- [x] There is reasonable content on the page (see: [No Content](https://github.com/js-org/js.org/wiki/No-Content))
- [x] I have read and accepted the [Terms and Conditions](http://js.org/terms.html)
