### PR TITLE
twitchx.js.org

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -2638,6 +2638,7 @@ var cnames_active = {
   "twentyfive": "luckyshot.github.io/twentyfive",
   "twikoo": "imaegoo.github.io/twikoo",
   "twitch": "twitchapis.github.io/twitch.js",
+  "twitchx": "cursorsdottsx.github.io/twitchx",
   "twitter": "twitterjs.github.io/website",
   "two": "jonobr1.github.io/two.js",
   "twt": "koj-co.github.io/twt",


### PR DESCRIPTION
Hi, I have a TypeScript Twitch API wrapper in development that is going very well and have created a [GitHub pages site](https://cursorsdottsx.github.io/twitchx/#/) with the current documentation, below is the contract:

- [x] There is reasonable content on the page (see: [No Content](https://github.com/js-org/js.org/wiki/No-Content))
- [x] I have read and accepted the [Terms and Conditions](http://js.org/terms.html)

Thank you in advance for a short and memorable domain everyone can use. 

❤️