### PR TITLE
meow.js.org

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -1538,6 +1538,7 @@ var cnames_active = {
   "meiosis": "foxdonut.github.io/meiosis", // noCF? (don´t add this in a new PR)
   "melies-hugo": "cristinafsanz.github.io/melies-hugo",
   "melody": "trivago.github.io/melody-web",
+  "meow": "meow-js.github.io",
   "memer-api": "cname.vercel-dns.com",
   "mengd": "cname.vercel-dns.com",
   "menghafalquran": "mzaini30.github.io/menghafal-quran",


### PR DESCRIPTION
- [x] There is reasonable content on the page (see: [No Content](https://github.com/js-org/js.org/wiki/No-Content))
- [x] I have read and accepted the [Terms and Conditions](http://js.org/terms.html)
Note: [meow-js.github.io](https://github.com/meow-js/meow-js.github.io) is generated by a [deployment action](https://github.com/meow-js/meow-js.github.io/blob/master/.github/workflows/deploy.yml). The generated files can be seen in the [gh-pages branch](https://github.com/meow-js/meow-js.github.io/tree/gh-pages), which houses the CNAME as well.