### PR TITLE
sqlchart.js.org

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -2423,6 +2423,7 @@ var cnames_active = {
   "spritewerk": "bildepunkt.github.io/spritewerk", // noCF? (don´t add this in a new PR)
   "sql": "sql-js.github.io/sql.js",
   "sql2struct": "ymlair.github.io/sql2struct",
+  "sqlchart": "sqlchart.github.io/sqlchart",
   "squeak": "bertfreudenberg.github.io/SqueakJS",
   "squid": "squidjs.github.io/squid",
   "squirrelly": "squirrellyjs.netlify.com", // noCF


### PR DESCRIPTION
this adds the live web-demo of sqlchart to https://sqlchart.js.org/spa.sqlchart.html.
sqlchart is an opensource, frontend-charting tool written in javascript and webassembly.

- [x] There is reasonable content on the page (see: [No Content](https://github.com/js-org/js.org/wiki/No-Content))
- [x] I have read and accepted the [Terms and Conditions](http://js.org/terms.html)
- [x] I have added file https://github.com/sqlchart/sqlchart/blob/gh-pages/CNAME with content `sqlchart.js.org`

![image](https://user-images.githubusercontent.com/280571/124658320-39590600-de69-11eb-82e8-a6f0f238e664.png)
