### PR TITLE
keyv.js.org

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -1311,6 +1311,7 @@ var cnames_active = {
   "kewitz": "kewitz.github.io",
   "keypress": "rumkin.github.io/keypress.js.org",
   "keystone": "keystone-ssg.netlify.app",
+  "keyv": "microlinkhq.github.io/keyv",
   "keyvify": "zyrouge.github.io/Keyvify",
   "kilic": "kiliczsh.github.io",
   "kilobyte": "kilobytehq.github.io/open-js",


### PR DESCRIPTION
Hey,

I wanted to add [keyv](https://github.com/microlinkhq/keyv), a simple key, value interface compatible with a lot of backend providers.


The project exist for a while (https://www.npmjs.com/package/keyv) and we are retaking the project moving it forward 🙂

__


- [x] There is reasonable content on the page (see: [No Content](https://github.com/js-org/js.org/wiki/No-Content))
- [x] I have read and accepted the [Terms and Conditions](http://js.org/terms.html)
