### PR TITLE
epi.js.org

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -811,7 +811,7 @@ var cnames_active = {
   "energy": "energychain.github.io/energy",
   "eon": "eon-web.github.io/eon",
   "epack": "transparent-dilophosaurus-d0z0nyrn79irf17c2hbbz9li.herokudns.com",
-  "epi": "quantalabs.github.io/EpiJS",
+  "epi": "epispot.github.io/EpiJS",
   "epicker": "eling486.github.io/EPicker-docs",
   "eplayer": "132yse.github.io/eplayer",
   "epoxy": "hosting.gitbook.com",


### PR DESCRIPTION
- [x] There is reasonable content on the page (see: [No Content](https://github.com/js-org/js.org/wiki/No-Content))
- [x] I have read and accepted the [Terms and Conditions](http://js.org/terms.html)

This PR updates a URL, from https://quantalabs.github.io/EpiJS, to https://epispot.github.io/EpiJS, as the project was transferred to an org.