### PR TITLE
camel case GitHub

### DIFF
--- a/layouts/_default/base.html
+++ b/layouts/_default/base.html
@@ -106,7 +106,7 @@
         {{else}}
         <div>
             <a id="oc" class="badge blue" title="Open Collective" href="https://opencollective.com/js-org" rel="nofollow noreferrer noopener" target="_blank"><span>Donate</span><span>for registrar fees</span></a>
-            <a id="gh" class="badge gray" title="GitHub" href="https://github.com/js-org/js.org" rel="nofollow noreferrer noopener" target="_blank"><span>Github</span>
+            <a id="gh" class="badge gray" title="GitHub" href="https://github.com/js-org/js.org" rel="nofollow noreferrer noopener" target="_blank"><span>GitHub</span>
                 {{if .Params.full}}
                 <span id="ghstars">3.6K</span>
                 {{end}}


### PR DESCRIPTION
- [x] There is reasonable content on the page (see: [No Content](https://github.com/js-org/js.org/wiki/No-Content))
- [x] I have read and accepted the [Terms and Conditions](http://js.org/terms.html)
