### PR TITLE
Rm https://

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -1052,7 +1052,7 @@ var cnames_active = {
   "gruft": "nikola.github.io/gruft", // noCF? (don´t add this in a new PR)
   "grumpy": "aidenybai.github.io/grumpy",
   "gtfs": "gtfs-js.github.io/gtfs.js.org",
-  "guilded": "https://guildedjs.github.io/guilded.js/",
+  "guilded": "guildedjs.github.io/guilded.js",
   "guilherme": "guilhermedelemos.github.io/guilherme",
   "guillotine": "matiasgagliano.github.io/guillotine", // noCF? (don´t add this in a new PR)
   "guineapigbot": "guineapigbot.github.io",


### PR DESCRIPTION
Noticed this when processing #6212 -- removes the `https://` prefix and the trailing slash from `guilded.js.org`
