### PR TITLE
nitrate.js.org

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -1781,6 +1781,7 @@ var cnames_active = {
   "ninh": "reeganexe.github.io/ninh",
   "nintenbot": "nintenzone.github.io/NintenBot",
   "nite": "manvalls.github.io/nite",
+  "nitrate": "ranjithrd.github.io/nitrate",
   "nnmap": "marzavec.github.io/nnmap.js",
   "no-pry": "zenyanle.github.io/node-unblocker",
   "nobelium": "cname.vercel-dns.com", // noCF


### PR DESCRIPTION
- [x] There is reasonable content on the page (see: [No Content](https://github.com/js-org/js.org/wiki/No-Content))
- [x] I have read and accepted the [Terms and Conditions](http://js.org/terms.html)

~Site: [ranjithrd.github.io/nitrate](https://ranjithrd.github.io/nitrate)~ 
*Edit: Because of some CNAME problems, domain right now is redirecting to nitrate.js.org. Please note that for that period of time the site will be inactive. I have uploaded a screenshot of the site running on Localhost down below.* 

Description: [GitHub README](https://github.com/ranjithrd/nitrate/blob/main/README.md)

Content: A very simple React starter based upon Vite.

<img width="1437" alt="Screenshot 2021-08-16 at 9 02 41 AM" src="https://user-images.githubusercontent.com/32879598/129508048-05804818-3bc1-4a63-bd5b-e0a7ebdf8d5f.png">