### PR TITLE
tauber.js.org

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -2597,6 +2597,7 @@ var cnames_active = {
   "taro": "nervjs.github.io/taro-website",
   "tart": "tart.github.io/tartJS", // noCF? (don´t add this in a new PR)
   "tatsumaki": "mrjacz.github.io/tatsumaki.js",
+  "tauber": "ranjithrd.github.io/tauber",
   "taufik-nurrohman": "taufik-nurrohman.github.io",
   "tauris": "codemaster138.github.io/tauris",
   "tayyab": "itayyab.github.io",


### PR DESCRIPTION
- [x] There is reasonable content on the page (see: [No Content](https://github.com/js-org/js.org/wiki/No-Content))
- [x] I have read and accepted the [Terms and Conditions](http://js.org/terms.html)

Because GitHub pages doesn't display content on the subdomain for some reason, I've made sure to deploy this to a secondary Netlify domain so that the maintainers can verify the site's relation to JS: https://tauber.netlify.app

The GitHub configuration is a bit unusual in this repo because of how Docusaurus works, see Pull Request #6222.

Thank you.