### PR TITLE
flare.js.org

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -930,6 +930,7 @@ var cnames_active = {
   "five": "jackdcrawford.github.io/five",
   "flamecord": "flamexode.github.io/flamecord",
   "flap": "slurmulon.github.io/flap",
+  "flare": "nsaunders.github.io/flare",
   "flash": "flashcardjs.github.io",
   "flatpickr": "flatpickr.github.io",
   "flavor": "blackmirror1980.github.io/flavor-js",


### PR DESCRIPTION
- [x] There is reasonable content on the page (see: [No Content](https://github.com/js-org/js.org/wiki/No-Content))
- [x] I have read and accepted the [Terms and Conditions](http://js.org/terms.html)

Note: The site appears to be broken right now because it doesn't work under a subdirectory (e.g. nsaunders.github.io/flare). This is due to a Next.js configuration issue that I have yet to resolve; however, the site should work fine once available at flare.js.org. Thanks for understanding!