### PR TITLE
linkify.js.org

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -1477,7 +1477,7 @@ var cnames_active = {
   "ling": "wangziling.github.io",
   "linghucong": "jiji262.github.io",
   "lingui": "cname.vercel-dns.com", // noCF
-  "linkify": "soapbox.github.io/linkifyjs",
+  "linkify": "hypercontext.github.io/linkifyjs",
   "lips": "jcubic.github.io/lips",
   "lipsum": "llxlr.github.io/lipsum.js",
   "lister": "jpbulman.github.io/lister",


### PR DESCRIPTION
- [x] There is reasonable content on the page (see: [No Content](https://github.com/js-org/js.org/wiki/No-Content))
- [x] I have read and accepted the [Terms and Conditions](http://js.org/terms.html)

linkify is now owned by the `hypercontext` org instead of `soapbox` 

Website: https://hypercontext.github.io/linkifyjs (already redirects)

<img width="758" alt="image" src="https://user-images.githubusercontent.com/1693461/133693759-f3d51bf8-bf62-469d-8acd-bbc7018a5343.png">

