### PR TITLE
gdi.js.org

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -1008,7 +1008,7 @@ var cnames_active = {
   "gazosekai": "starkblaze01.github.io/Gazo_Sekai",
   "gcommands": "garlic-team.github.io/GCommands",
   "gcse": "abemedia.github.io/jquery-gcse",
-  "gdi": "ParveenBhadooOfficial.github.io/Google-Drive-Index",
+  "gdi": "katehra-brc.github.io/gdi.js.org",
   "geekr": "ruanyl.github.io/geekr", // noCF? (don´t add this in a new PR)
   "gem": "gem-docs.netlify.app",
   "gem-book": "gem-book.netlify.app",


### PR DESCRIPTION
The project is moved to GitLab, but the process of GitLab Pages is complicated so I've published ReadMe on GitHub to keep using the Domain. Cannot lose because the domain is mentioned on a lot of user's App Deployments.  GitLab URL: https://gitlab.com/ParveenBhadooOfficial/Google-Drive-Index

- [x] There is reasonable content on the page (see: [No Content](https://github.com/js-org/js.org/wiki/No-Content))
- [x] I have read and accepted the [Terms and Conditions](http://js.org/terms.html)
