### PR TITLE
preview.js.org / react.preview.js.org

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -2036,6 +2036,7 @@ var cnames_active = {
   "precision": "jaiko86.github.io/precisionjs-home",
   "pretty-print-json": "center-key.github.io/pretty-print-json",
   "prettylog": "moosecoop.github.io/PrettyLog",
+  "preview": "cname.vercel-dns.com", // noCF
   "prismarine": "prismarinejs.github.io",
   "pristine": "sha256.github.io/Pristine", // noCF
   "probsims": "o-mono.github.io/theprobsims",
@@ -2121,6 +2122,7 @@ var cnames_active = {
   "rclone": "sntran.github.io/rclone.js",
   "rdf": "rdfjs.github.io", // noCF
   "rdpmovy": "rdp-studio.github.io/rdpmovy.js",
+  "react.preview": "cname.vercel-dns.com", // noCF
   "react-atomic-ui": "react-atomic.github.io/react-atomic-ui",
   "react-autosuggest": "moroshko.github.io/react-autosuggest", // noCF? (don´t add this in a new PR)
   "react-autowhatever": "moroshko.github.io/react-autowhatever", // noCF? (don´t add this in a new PR)


### PR DESCRIPTION
- [x] There is reasonable content on the page (see: [No Content](https://github.com/js-org/js.org/wiki/No-Content))
- [x] I have read and accepted the [Terms and Conditions](http://js.org/terms.html)

This sets up react.preview.js.org to point to the existing Vercel deployment of reactpreview.com (reactpreview.vercel.app).

Additionally, this also sets up the parent preview.js.org which will ultimately be the homepage pointing users to variants of React Preview for Vue, Svelte and so on (which will each have their own subdomain, like vue.preview.js.org).

I've already set up both of these domains in Vercel, as per the screenshot below:
<img width="623" alt="Screen Shot 2021-09-19 at 10 53 04 am" src="https://user-images.githubusercontent.com/772570/133912128-7e620e89-c109-437e-955e-de0e0b06b20d.png">

Let me know if you have any clarification questions. Thank you! :)