### PR TITLE
tiden.js.org

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -2672,7 +2672,7 @@ var cnames_active = {
   "ths": "ths-fe.github.io",
   "thundercats": "thundercatsjs.github.io/thundercats", // noCF? (don´t add this in a new PR)
   "tictactoe": "jeff-tian.github.io/tic-tac-toe-ai",
-  "tiden": "tidenjs.github.io/tiden",
+  "tiden": "tidenjs.netlify.app",
   "tidy": "tidy-js.github.io",
   "tie": "tie-team.github.io",
   "timeout": "anshuman-verma.github.io/setTimeout",


### PR DESCRIPTION
- [x] There is reasonable content on the page (see: [No Content](https://github.com/js-org/js.org/wiki/No-Content))
- [x] I have read and accepted the [Terms and Conditions](http://js.org/terms.html)

We're moving to Netlify because GH pages don't support redirects. This is a deal-breaker for us, as we're a framework for building SPA, all routes are handled client-side.