### PR TITLE
adv.js.org

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -95,7 +95,7 @@ var cnames_active = {
   "aditya": "aditya81070.github.io",
   "adnanbabakan": "adnanbabakan.github.io",
   "adon988": "adon988.github.io",
-  "adv": "yunyoujun.github.io/advjs",
+  "adv": "advjs.github.io",
   "advancedrpc": "advancedrpc.github.io",
   "aeon": "flazepe.github.io/aeon-web",
   "affiliate": "russellsteadman.github.io/affiliate",


### PR DESCRIPTION
> Reverts js-org/js.org#6411

Sorry to interrupt again, I purchased a new `advjs.org` domain name, so I decided to redirect it back to the original CNAME.