### PR TITLE
gost.js.org

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -1073,6 +1073,7 @@ var cnames_active = {
   "gotanda": "gotandajs.github.io",
   "gottasurf": "jottocraft.github.io/surf",
   "govind": "emgk.github.io",
+  "gost": "gost.martiaforoud.repl.co",
   "graffy": "aravindet.github.io/graffy",
   "gram": "gram-js.github.io/docs",
   "gramps": "gramps-graphql.github.io/gramps",


### PR DESCRIPTION
What is gost?

Gost is a service for you to host single page applications without any effort. Just run a single command to publish your gost app to the cloud.

- [x] There is reasonable content on the page (see: [No Content](https://github.com/js-org/js.org/wiki/No-Content))
- [x] I have read and accepted the [Terms and Conditions](http://js.org/terms.html)
