### PR TITLE
argon.js.org

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -194,7 +194,6 @@ var cnames_active = {
   "arga": "cname.vercel-dns.com",
   "argaghulamahmad": "argaghulamahmad.github.io",
   "argo": "albertosantini.github.io/argo", // noCF? (don´t add this in a new PR)
-  "argon": "suspicious-thompson-8ecfb9.netlify.app",
   "ari": "arbo77.github.io/ari",
   "ariang": "p3terx.github.io/ariang", // noCF
   "arief": "1997arief.github.io",


### PR DESCRIPTION
Hello,

As of the original pull request (#5005), I had requested to have [argon.js.org](https://argon.js.org) to be accepted.
This project has now been abandoned (and it now no-longer is allowed).

I would like to request to have this removed from js.org.

Thanks,
Pixwl