### PR TITLE
craft.js.org

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -580,7 +580,7 @@ var cnames_active = {
   "cqrs": "adrai.github.io/cqrs", // noCF? (don´t add this in a new PR)
   "cr": "echosoar.github.io/cr",
   "cracked": "billorcutt.github.io/Cracked",
-  "craft": "prevwong.github.io/craft.js",
+  "craft": "craftjs.netlify.app",
   "crank": "bikeshaving.github.io/crank",
   "crawlx": "wind2sing.github.io/crawlx",
   "creamcrop": "creamcropdev.github.io",


### PR DESCRIPTION
Move craft.js.org from prevwong.github.io/craft.js to craftjs.netlify.app

- [x] There is reasonable content on the page (see: [No Content](https://github.com/js-org/js.org/wiki/No-Content))
- [x] I have read and accepted the [Terms and Conditions](http://js.org/terms.html)
