### PR TITLE
lite-web-server.js.org

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -1527,7 +1527,7 @@ var cnames_active = {
   "liquid-ajax-cart": "evgeniymukhamedjanov.github.io/liquid-ajax-cart",
   "lister": "jpbulman.github.io/lister",
   "listore": "yieldray.github.io/listore",
-  "lite-web-server": "lite-web-server.github.io",
+  "lite-web-server": "chasyumen.github.io/lite-web-server",
   "litedom": "mardix.github.io/litedom", // noCF
   "lithium": "ranjithrd.github.io/lithium",
   "littlefoot": "goblindegook.github.io/littlefoot",


### PR DESCRIPTION
Move craft.js.org from lite-web-server.github.io to chasyumen.github.io/lite-web-server

- [x] There is reasonable content on the page (see: [lite-web-server.js.org](https://github.com/chasyumen/lite-web-server/tree/gh-pages)
- [x] I have read and accepted the [Terms and Conditions](http://js.org/terms.html) 