### PR TITLE
www.next-auth.js.org

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -3053,6 +3053,7 @@ var cnames_active = {
   "wugenqiang": "wugenqiang.github.io/wugenqiang.js.org",
   "wwcache": "wwcache.github.io",
   "www.siddharth": "chaudhs769.github.io/siddharth.js.org", // noCF
+  "www.next-auth": "cname.vercel-dns.com", // noCF
   "wyfe": "wangyuanstudio.github.io/WYFE", // noCF? (don´t add this in a new PR)
   "wynncraft": "frawolf.github.io/wynncraft.js",
   "wysc": "coffeebank.github.io/wysc-vue",


### PR DESCRIPTION
add `www.next-auth.js.org` variant. 

`next-auth.js.org` already exists, we just wanted to add the `www` prefixed version.

This is for a docs page for an opensource js library, [`next-auth`](https://github.com/nextauthjs/next-auth).

CC: @balazsorban44

- [x] There is reasonable content on the page (see: [No Content](https://github.com/js-org/js.org/wiki/No-Content))
- [x] I have read and accepted the [Terms and Conditions](http://js.org/terms.html)
