### PR TITLE
simple-pip.js.org

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -2493,7 +2493,7 @@ var cnames_active = {
   "simonhans": "simonhans.github.io",
   "simpldb": "hosting.gitbook.io", // noCF
   "simple": "lescinskiscom.github.io/simple-js",
-  "simple-pip": "sleepiie.github.io/simple-pip",
+  "simple-pip": "frogweezer.github.io/simple-pip",
   "simplecounter": "tomkiernan120.github.io/simplecounter",
   "simplecrypto": "danang-id.github.io/simple-crypto-js",
   "simpler-state": "arnelenero.github.io/simpler-state",


### PR DESCRIPTION
I recently changed my GitHub username and I'd like to update an old JS.org domain to match my new username.

Original PR: https://github.com/js-org/js.org/pull/5753
Repo: https://github.com/frogweezer/simple-pip

Thanks :)