### PR TITLE
frost.js.org

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -1030,7 +1030,7 @@ var cnames_active = {
   "front-end": "whoisjorge.github.io/front-end",
   "frontless": "nesterow.github.io/frontless",
   "fronts": "unadlib.github.io/fronts",
-  "frost": "devsnowflake.github.io/frost",
+  "frost": "cesiumlabs.github.io/frost",
   "frzr": "pakastin.github.io/frzr",
   "fs-nextra": "bdistin.github.io/fs-nextra",
   "fte": "scintilla4evr.github.io/fte",


### PR DESCRIPTION
- [x] There is reasonable content on the page (see: [No Content](https://github.com/js-org/js.org/wiki/No-Content))
- [x] I have read and accepted the [Terms and Conditions](http://js.org/terms.html)

> Reason: DevSnowflake rebranded to CesiumLabs