### PR TITLE
phaker.js.org

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -2052,6 +2052,7 @@ var cnames_active = {
   "pguth": "pguth.github.io",
   "ph1p": "ph1p.github.io",
   "pharaoh": "pharaoh-js.github.io", // noCF? (don´t add this in a new PR)
+  "phaker": "phakerjs.github.io/phaker.js",
   "phi": "phi-tools.netlify.com",
   "phobos": "phobosjs.github.io/phobos.js",
   "phoenix35": "phoenix35.github.io/js-help",


### PR DESCRIPTION
phaker.js picks up where faker.js left off. The original maintainer essentially resigned 🤷

https://phakerjs.github.io/phaker.js/ => https://phaker.js.org

- [x] There is reasonable content on the page (see: [No Content](https://github.com/js-org/js.org/wiki/No-Content))
- [x] I have read and accepted the [Terms and Conditions](http://js.org/terms.html)
