### PR TITLE
Add redirect to emberjs.com

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -864,6 +864,7 @@ var cnames_active = {
   "email-templates": "niftylettuce.github.io/email-templates",
   "embarrassed-themes": "kbothub.github.io/Embarrassed-Themes",
   "embedlam": "wnda.github.io/embedlam",
+  "ember": "emberjs.com",
   "ember-cli-page-object": "san650.github.io/ember-cli-page-object", // noCF? (don´t add this in a new PR)
   "ember-electron": "adopted-ember-addons.github.io/ember-electron",
   "emeraldcraftmc": "emeraldcraftmc.github.io", // noCF? (don´t add this in a new PR)


### PR DESCRIPTION
is this allowed?
I couldn't find any documentation on this or not, but it seems some entries in this file redirect to other places, such as:
- eta
- frankosca
- inko
(etc)

:shrug:

- [x] There is reasonable content on the page (see: [No Content](https://github.com/js-org/js.org/wiki/No-Content))
- [x] I have read and accepted the [Terms and Conditions](http://js.org/terms.html)
