### PR TITLE
gun-vue.js.org

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -1151,6 +1151,7 @@ var cnames_active = {
   "gully": "nmabhinandan.github.io/gully", // noCF? (don´t add this in a new PR)
   "gulpkit": "gulpkit.github.io/GulpKit",
   "gun": "gundb.github.io", // noCF? (don´t add this in a new PR)
+  "gun-vue": "defucc.github.io/gun-vue", //noCF
   "guppy": "daniel3735928559.github.io/guppy",
   "gustwind": "gustwind.netlify.app",
   "gylidian": "gylidian.github.io",


### PR DESCRIPTION
The site is configured to be hosted from a root level and so doesn't show the pages properly while it's on  defucc.github.io/gun-vue - there's a demo only there, but will add some docs soon

The actual repo is here https://github.com/DeFUCC/gun-vue and it's definitely related to js ✨

- [x] There is reasonable content on the page (see: [No Content](https://github.com/js-org/js.org/wiki/No-Content))
- [x] I have read and accepted the [Terms and Conditions](http://js.org/terms.html)
