### PR TITLE
wiki.js.org

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -3077,7 +3077,7 @@ var cnames_active = {
   "wice": "yulioaj290.github.io/wice.js",
   "wii": "andrewplus.github.io/Wii.JS",
   "wiimmfi": "hosting.gitbook.io", // noCF
-  "wiki": "wikijs.netlify.com", // noCF
+  "wiki": "wiki-js-org.netlify.app", // noCF
   "wikidata-elements": "lisongx.github.io/wikidata-elements",
   "wildfire": "cheng-kang.github.io/wildfire",
   "willy": "willyarisky.github.io/willy",


### PR DESCRIPTION
- [x] There is reasonable content on the page (see: [No Content](https://github.com/js-org/js.org/wiki/No-Content))
- [x] I have read and accepted the [Terms and Conditions](http://js.org/terms.html)

This is a PR to update the existing CNAME for wiki.js.org to point to a new Netlify site, in order to conform with the no redirect policy. Thanks!
