### PR TITLE
mega.js.org

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -1688,6 +1688,7 @@ var cnames_active = {
   "medium-converter": "gunar.github.io/medium-converter", // noCF
   "meed": "pinjasaur.github.io/meed",
   "meet": "twtg93.github.io/MeetJS",
+  "mega": "qgustavor.github.io/megajs-docs",
   "meiosis": "foxdonut.github.io/meiosis", // noCF? (don´t add this in a new PR)
   "melies-hugo": "cristinafsanz.github.io/melies-hugo",
   "melody": "trivago.github.io/melody-web",


### PR DESCRIPTION
- [x] There is reasonable content on the page (see: [No Content](https://github.com/js-org/js.org/wiki/No-Content))
- [x] I have read and accepted the [Terms and Conditions](http://js.org/terms.html)

That will be the homepage and documentation of [megajs](https://github.com/qgustavor/mega/) library since I will be releasing [a new major version](https://github.com/qgustavor/mega/pull/86) soon and the current documentation in the wiki is not sufficiently good.

I put the website in a different repository to make it easier to update. I think that will not be a problem but if needed I can set up the GitHub Action to deploy on https://qgustavor.github.io/mega/ instead of https://qgustavor.github.io/megajs-docs/.