### PR TITLE
Add `use-github`

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -2846,6 +2846,7 @@ var cnames_active = {
   "use-cookie-consent": "use-cookie-consent.github.io/use-cookie-consent-docs",
   "usedapp": "crypto-meta.github.io/usedapp.js.org",
   "useful-apis": "yuu0007.github.io/useful-apis",
+  "use-github":"ultirequiem.github.io/use-github",
   "useless-machine": "pakastin.github.io/useless-machine",
   "userfetch": "userfetch.github.io",
   "usernamegen": "aryan02420.github.io/usernamegen",


### PR DESCRIPTION
- [x] There is reasonable content on the page (see: [No Content](https://github.com/js-org/js.org/wiki/No-Content))
- [x] I have read and accepted the [Terms and Conditions](http://js.org/terms.html)

Currently, https://ultirequiem.github.io/use-github moves you to https://js.org/302?use-github.js because I already put the CNAME

You can see the page on 👇🏽 

https://use-github.netlify.app/

Thanks for this service!