### PR TITLE
read-from-fs.js.org

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -2225,6 +2225,7 @@ var cnames_active = {
   "reactpatterns": "reactpatterns.github.io",
   "reactql": "leebenson.github.io/reactql-site",
   "reactsearch": "anujsharma141.github.io/reactsearch",
+  "read-from-fs": "ultirequiem.github.io/read-from-fs",
   "readcolor": "keiww.github.io/readcolorhex",
   "readit": "teebu.github.io/readit",
   "realsee": "realsee-developer.github.io",


### PR DESCRIPTION
- [x] There is reasonable content on the page (see: [No Content](https://github.com/js-org/js.org/wiki/No-Content))
- [x] I have read and accepted the [Terms and Conditions](http://js.org/terms.html)

Currently, https://ultirequiem.github.io/read-from-fs moves you to https://js.org/302?read-from-fs.js because I already put the CNAME

Source https://github.com/UltiRequiem/read-from-fs/tree/gh-pages

Similar to #6977 or #6980