### PR TITLE
risingstars.js.org

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -2328,7 +2328,7 @@ var cnames_active = {
   "riot": "riot.github.io",
   "riotgear": "riotgear.github.io",
   "rishi": "rishiosaur.github.io",
-  "risingstars": "cname.vercel-dns.com",
+  "risingstars": "cname.vercel-dns.com", // noCF
   "risingstars2016": "michaelrambeau.github.io/risingstars2016",
   "rize": "g-plane.github.io/rize",
   "rmodal": "zewish.github.io/rmodal.js",


### PR DESCRIPTION
Hello Stefan and all amazing people behind `js.org` domain! 👋 

I noticed today https://risingstars.js.org/ is broken.

![image](https://user-images.githubusercontent.com/5546996/158056247-09a77d0e-37f6-4a16-a4bc-0193aedcfe51.png)

Comparing with the other sites hosted on Vercel, I think it's because Cloudflare is not needed (other apps on Vercel with the Cloudflare option are broken too, while the ones without are fine)

So it would be great if you could update the configuration for the _Rising Stars_!

Thank you in advance! 🙏 

Related (from another user): https://github.com/js-org/js.org/pull/7023 (I guess it's not a coincidence!)

Note: I don't know why it used to work until yesterday 😅 

- [x] There is reasonable content on the page (see: [No Content](https://github.com/js-org/js.org/wiki/No-Content))
- [x] I have read and accepted the [Terms and Conditions](http://js.org/terms.html)
