### PR TITLE
Fix bad GitHub ref logic in actions

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -11,8 +11,14 @@ on:
 jobs:
   validate:
     runs-on: ubuntu-latest
+
+    env:
+      GH_EVENT_HASH: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
+
     steps:
       - uses: actions/checkout@v3
+        with:
+          ref: ${{ env.GH_EVENT_HASH }}
 
       - uses: actions/checkout@v3
         with:


### PR DESCRIPTION
Fixes https://github.com/js-org/js.org-cleanup/issues/11

By default, for some odd reason, actions/checkout will use a merge commit for PRs which has some benefits in some situations, but for us results in the error line number annotations being reported incorrectly. This PR updates the workflow to use the actual commit the PR is on, rather than a merge, following the suggestion from https://github.com/actions/checkout#Checkout-pull-request-HEAD-commit-instead-of-merge-commit