### PR TITLE
conflict.js.org

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -541,7 +541,7 @@ var cnames_active = {
   "condition": "mg98.github.io/condition.js",
   "conductor": "hosting.gitbook.com",
   "confetti": "matteobruni.github.io/confetti",
-  "conflict": "yodalightsabr.github.io/conflict-website",
+  "conflict": "conflictjs.github.io/site",
   "conglo": "schwarzkopfb.github.io/conglo",
   "consent": "datamart.github.io/Consent",
   "consono": "r37r0m0d3l.github.io/consono",


### PR DESCRIPTION
I added conflict.js.org a while back in #6850, but I just moved it to the GitHub org conflictjs instead of my personal account.
The websites are the same, I just want to get stuff onto the org.

- [x] There is reasonable content on the page (see: [No Content](https://github.com/js-org/js.org/wiki/No-Content))
- [x] I have read and accepted the [Terms and Conditions](http://js.org/terms.html)
