### PR TITLE
bsb.js.org

### DIFF
--- a/ns_active.js
+++ b/ns_active.js
@@ -14,6 +14,7 @@
 
 var ns_active = {
   "appshelf": ["ns31.cloudns.net", "ns32.cloudns.net", "ns33.cloudns.net", "ns34.cloudns.net"],
+  "bsb": ["ns10.domains.betterweb.co.za", "ns11.domains.betterweb.co.za", "ns12.domains.betterweb.co.za", "ns13.domains.betterweb.co.za"],
   "castyte": ["ns31.cloudns.net", "ns32.cloudns.net", "ns33.cloudns.net", "ns34.cloudns.net"],
   "engine262": ["brad.ns.cloudflare.com", "lia.ns.cloudflare.com"],
   "lolifamily": ["glen.ns.cloudflare.com", "melany.ns.cloudflare.com"],


### PR DESCRIPTION
Adding Better-Service-Base - https://github.com/BetterCorp/better-service-base :) 
^ Docs are in the documentation branch

There are a bunch of plugins - and each plugin will get a sub-sub-domain - thus the NS record, over a cname
^ See this group for some of the plugins: https://gitlab.com/BetterCorp/BetterServiceBase

- [x] There is reasonable content on the page (see: [No Content](https://github.com/js-org/js.org/wiki/No-Content))
^ will be active once the domain is active (temp site: https://bettercorp.gitlab.io/BetterServiceBase/service-base/).
- [x] I have read and accepted the [Terms and Conditions](http://js.org/terms.html)
