### PR TITLE
api.js.org

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -173,6 +173,7 @@ var cnames_active = {
   "anukul": "anukul.github.io",
   "aoi": "aoijs.github.io/website",
   "aom": "scarych.github.io/aom",
+  "api": "cname.vercel-dns.com", // noCF
   "api-spec": "api-spec.github.io", // noCF? (don´t add this in a new PR)
   "apicluster": "ramsunvtech.github.io/apicluster", // noCF? (don´t add this in a new PR)
   "apilyertia": "apilyertia.github.io",


### PR DESCRIPTION
Add `api` to the list.

Not sure if this is allowed, but i plan to make a api network with a bunch of apis built by the open source community, currently i have a rps(rock, paper, scissors) api.
It can be viewed at https://rps://rps.gamertike.com (i plan to move to api.js.org if possible). This is prove i have some content on my page.

- [x] There is reasonable content on the page (see: [No Content](https://github.com/js-org/js.org/wiki/No-Content))
- [x] I have read and accepted the [Terms and Conditions](http://js.org/terms.html)
