### PR TITLE
disdai.js.org

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -744,7 +744,6 @@ var cnames_active = {
   "discords": "botstudios.github.io/discords.js.org",
   "discordutility": "chaosphoe.github.io/discordutility",
   "discuss": "cname.vercel-dns.com", // noCF
-  "disdai": "disdai.github.io/disdai-website",
   "display": "arguiot.github.io/DisplayJS",
   "distillery": "achannarasappa.github.io/distillery", // noCF? (don´t add this in a new PR)
   "distri": "flarp.github.io/Distri.js",


### PR DESCRIPTION
I'd like to remove disdai.js.org as it isn't being used nor maintained anymore. Thanks

- [x] There is reasonable content on the page (see: [No Content](https://github.com/js-org/js.org/wiki/No-Content))
- [x] I have read and accepted the [Terms and Conditions](http://js.org/terms.html)
