### PR TITLE
canvasui.js.org

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -421,7 +421,6 @@ var cnames_active = {
   "canvas": "anshuman-verma.github.io/canvas",
   "canvas-datagrid": "tonygermaneri.github.io/canvas-datagrid",
   "canvasconstructor": "kyranet.github.io/canvas-constructor",
-  "canvasui": "voidlzl.github.io/CanvasUI",
   "canvg": "canvg.github.io/canvg",
   "canvo": "canvojs.github.io",
   "capital": "capitaljs.github.io/capitaljs",


### PR DESCRIPTION
Via email:

> Hi, I got canvasui.js.org three months ago, but for some reason, I deleted my github account, so canvasui.js.org now returns 404. Recently I plan to refactor canvasui (a canvas-based javascript framework) and publish it on another github account, so please clear canvasui.js.org.

Confirmed the subdomain now returns a 404, and was requested by a ghost account: #6933