### PR TITLE
illustrator.js.org

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -1285,6 +1285,7 @@ var cnames_active = {
   "ignite": "ignitejscl.github.io",
   "iiimix": "iiimix.github.io/iiimixjsorg",
   "iio": "iioinc.github.io/iio.js", // noCF? (don´t add this in a new PR)
+  "illustrator": "illustratorjs.netlify.app",
   "imagecapture": "googlechrome.github.io/imagecapture-polyfill",
   "imagine": "karimayachi.github.io/imagine",
   "imask": "unmanner.github.io/imaskjs",


### PR DESCRIPTION
- [x] There is reasonable content on the page (see: [No Content](https://github.com/js-org/js.org/wiki/No-Content))
- [x] I have read and accepted the [Terms and Conditions](http://js.org/terms.html)

I am requesting `illustrator.js.org` for our [Illustrator.js JavaScript framework](https://github.com/CesiumLabs/illustrator.js). The website is hosted by https://netlify.com and can be accessed at https://illustratorjs.netlify.app
