### PR TITLE
vavilon.js.org

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -2985,7 +2985,6 @@ var cnames_active = {
   "vant-react-native": "youngjuning.github.io/vant-react-native",
   "vapory": "vaporyjs.github.io",
   "various": "variousjs.github.io/website",
-  "vavilon": "vavilon-js.github.io",
   "vayne": "vaynejs.github.io",
   "vbuild": "egoist.github.io/vbuild",
   "vcodes": "elitenover.github.io/vCodes-Docs",


### PR DESCRIPTION
- [x] There is reasonable content on the page (see: [No Content](https://github.com/js-org/js.org/wiki/No-Content))
- [x] I have read and accepted the [Terms and Conditions](http://js.org/terms.html)

I am sunsetting development of [vavilon.js](https://github.com/kytta/vavilon) (previously at https://github.com/vavilon-js/vavilon.js, added in #3185). The project is unmaintained, so I am freeing the domain name.