### PR TITLE
aries.js.org

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -197,6 +197,7 @@ var cnames_active = {
   "ari": "arbo77.github.io/ari",
   "ariang": "p3terx.github.io/ariang", // noCF
   "arief": "1997arief.github.io",
+  "aries": "hyperledger.github.io/aries-javascript-docs",
   "arime": "ninbryan.github.io/arime", // noCF? (don´t add this in a new PR)
   "arithmy": "arithmy.netlify.app",
   "arshad": "arshadmhabib.github.io",


### PR DESCRIPTION
- [x] There is reasonable content on the page (see: [No Content](https://github.com/js-org/js.org/wiki/No-Content))
- [x] I have read and accepted the [Terms and Conditions](http://js.org/terms.html)

Adds a mapping for aries.js.org to hyperledger.github.io/aries-javascript-docs. If we remove the javascript and docs parts (which seems acceptable from reading the docs) we keep the aries part. I'm one of the main contributors to this repo and also a member of the hyperledger organization (that hosts the repo)

