### PR TITLE
game-tracker.js.org

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -1072,7 +1072,7 @@ var cnames_active = {
   "g-point": "bdvela.github.io/g-point",
   "gaiman": "jcubic.github.io/gaiman",
   "gal": "galmail.github.io", // noCF? (don´t add this in a new PR)
-  "game-tracker": "endbug.github.io/game-tracker-docs",
+  "game-tracker": "game-tracker-docs.vercel.app",
   "gamecord": "gamecord.lazyowl.repl.co", // noCF
   "gamedevcontestal": "fromdenisvieira.github.io/gamedevcontestal", // noCF? (don´t add this in a new PR)
   "gametime": "parking-master.github.io/Gametime.js",


### PR DESCRIPTION
- [x] There is reasonable content on the page (see: [No Content](https://github.com/js-org/js.org/wiki/No-Content))
- [x] I have read and accepted the [Terms and Conditions](http://js.org/terms.html)

Sorry for opening a PR again 🙏🏻 , but I've decided to move the website to Vercel.
I've read #6870 and I'm having a similar error: I don't know if it's because it's still pointing to GitHub pages or because of Cloudflare... Should I add `//noCF`?

https://github.com/EndBug/game-tracker-docs