### PR TITLE
remove disgrowth.js.org / add disgrow.js.org

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -752,7 +752,7 @@ var cnames_active = {
   "discordutility": "chaosphoe.github.io/discordutility",
   "discuss": "cname.vercel-dns.com", // noCF
   "disgroupdev": "disgroup-development.github.io/disgroupdev.js",
-  "disgrowth": "sinkaroid.github.io/disgrowth",
+  "disgrow": "sinkaroid.github.io/disgrow",
   "display": "arguiot.github.io/DisplayJS",
   "distillery": "achannarasappa.github.io/distillery", // noCF? (don´t add this in a new PR)
   "distri": "flarp.github.io/Distri.js",


### PR DESCRIPTION
Hi, thanks for this dedicated services, need a little changes here.
> Motivation to change: name is hard to spelling, decided to simplify the name
https://www.npmjs.com/package/disgrow
- [x] There is reasonable content on the page (see: [No Content](https://github.com/js-org/js.org/wiki/No-Content))
- [x] I have read and accepted the [Terms and Conditions](http://js.org/terms.html)
