### PR TITLE
cn.redux.js.org

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -517,7 +517,7 @@ var cnames_active = {
   "cn.history": "doodlewind.github.io/jshistory-cn", // noCF
   "cn.iflow": "unadlib.github.io/iflow-docs-cn",
   "cn.mobx": "sangka.github.io/mobx-docs-cn", // noCF
-  "cn.redux": "nefe.github.io/redux-in-chinese", // noCF? (don´t add this in a new PR)
+  "cn.redux": "nefe.github.io/redux-in-chinese",
   "cn.rx": "rxjs-cn.github.io/RxJS-Docs-CN", // noCF
   "cnc": "cncjs.github.io/cncjs.org",
   "cndrew": "codemaster233.github.io",

--- a/cnames_active.js
+++ b/cnames_active.js
@@ -515,9 +515,9 @@ var cnames_active = {
   "cmdhub": "thatonetqnk.github.io/cmdhub",
   "cml": "didi.github.io/chameleon",
   "cn.history": "doodlewind.github.io/jshistory-cn", // noCF
-  "cn.iflow": "unadlib.github.io/iflow-docs-cn",
+  "cn.iflow": "unadlib.github.io/iflow-docs-cn", // noCF
   "cn.mobx": "sangka.github.io/mobx-docs-cn", // noCF
-  "cn.redux": "nefe.github.io/redux-in-chinese",
+  "cn.redux": "nefe.github.io/redux-in-chinese", // noCF
   "cn.rx": "rxjs-cn.github.io/RxJS-Docs-CN", // noCF
   "cnc": "cncjs.github.io/cncjs.org",
   "cndrew": "codemaster233.github.io",

--- a/cnames_active.js
+++ b/cnames_active.js
@@ -517,7 +517,7 @@ var cnames_active = {
   "cn.history": "doodlewind.github.io/jshistory-cn", // noCF
   "cn.iflow": "unadlib.github.io/iflow-docs-cn",
   "cn.mobx": "sangka.github.io/mobx-docs-cn", // noCF
-  "cn.redux": "camsong.github.io/redux-in-chinese", // noCF? (don´t add this in a new PR)
+  "cn.redux": "nefe.github.io/redux-in-chinese", // noCF? (don´t add this in a new PR)
   "cn.rx": "rxjs-cn.github.io/RxJS-Docs-CN", // noCF
   "cnc": "cncjs.github.io/cncjs.org",
   "cndrew": "codemaster233.github.io",


### PR DESCRIPTION
Recently I renamed camsong.github.io/redux-in-chinese to nefe.github.io/redux-in-chinese

CNAME is still existed.
https://github.com/nefe/redux-in-chinese/blob/master/CNAME

Could you help me to merge this, thanks.

- [x] There is reasonable content on the page (see: [No Content](https://github.com/js-org/js.org/wiki/No-Content))
- [x] I have read and accepted the [Terms and Conditions](http://js.org/terms.html)
