### PR TITLE
proxy.meow.js.org

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -2224,6 +2224,7 @@ var cnames_active = {
   "prototyped": "ardalanamini.github.io/prototyped.js",
   "protype": "arguiot.github.io/ProType",
   "proyecto-estadistica-2020": "eduardodevop.github.io/proyecto-estadistica-2020",
+  "proxy.meow": "cname.vercel-dns.com",
   "pruf": "signalwerk.github.io/pruf",
   "pruthvisoni": "pruthvisooni.github.io",
   "ps": "spindlyskit.github.io/ps.js",

--- a/cnames_active.js
+++ b/cnames_active.js
@@ -2223,8 +2223,8 @@ var cnames_active = {
   "protonio": "aktilacengiz.github.io/protonio",
   "prototyped": "ardalanamini.github.io/prototyped.js",
   "protype": "arguiot.github.io/ProType",
+  "proxy.meow": "cname.vercel-dns.com", // noCF
   "proyecto-estadistica-2020": "eduardodevop.github.io/proyecto-estadistica-2020",
-  "proxy.meow": "cname.vercel-dns.com",
   "pruf": "signalwerk.github.io/pruf",
   "pruthvisoni": "pruthvisooni.github.io",
   "ps": "spindlyskit.github.io/ps.js",


### PR DESCRIPTION
This subdomain will be used to host a proxy site for applications accessing scratch, since Scratch has blocked replit for some reason.
See @FunctionalMetatable for proof that I am the original applicant of the subdomain meow.js.org.

- [x] There is reasonable content on the page (see: [No Content](https://github.com/js-org/js.org/wiki/No-Content))
- [x] I have read and accepted the [Terms and Conditions](http://js.org/terms.html)
