### PR TITLE
react-native-error-boundary.js.org

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -2324,6 +2324,7 @@ var cnames_active = {
   "react-native-csv": "react-native-csv.github.io",
   "react-native-document-scanner": "websitebeaver.github.io/react-native-document-scanner-plugin",
   "react-native-elements": "react-native-elements.github.io/playground",
+  "react-native-error-boundary": "cname.vercel-dns.com", // noCF
   "react-native-flex-layout": "react-native-flex-layout.vercel.app",
   "react-native-floating-labels": "mayank-patel.github.io/react-native-floating-labels",
   "react-native-track-player": "doublesymmetry.github.io/react-native-track-player", // noCF


### PR DESCRIPTION
## Description

Hey! 👋🏼 

This PR adds a new domain for `react-native-error-boundary`.

👉🏼 You can find the project site here - https://react-native-error-boundary.vercel.app
👉🏼 GitHub repository: https://github.com/carloscuesta/react-native-error-boundary

Thanks! 🙏🏼 😍 

## Checks

- [x] There is reasonable content on the page (see: [No Content](https://github.com/js-org/js.org/wiki/No-Content))
- [x] I have read and accepted the [Terms and Conditions](http://js.org/terms.html)
