### PR TITLE
tracktask.js.org

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -2949,6 +2949,7 @@ var cnames_active = {
   "torlondev": "torlondev.github.io",
   "torpedo": "divysrivastava.github.io/torpedo.js",
   "trace": "andreasmadsen.github.io/trace",
+  "tracktask": "cname.vercel-dns.com", // noCF
   "trakas": "trakas.github.io",
   "translate": "xuanzhi33.github.io/translate.js",
   "transposer": "francesco-dipi.github.io/transposer",


### PR DESCRIPTION
- [x] There is reasonable content on the page (see: [No Content](https://github.com/js-org/js.org/wiki/No-Content))
(Please see https://dev-tracktask.vercel.app for the "reasonable content," it will eventually be deployed to https://tracktask.vercel.app but I would like to replace the latter with the `.js.org` domain.)
- [x] I have read and accepted the [Terms and Conditions](http://js.org/terms.html)