### PR TITLE
rema.js.org

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -1453,7 +1453,7 @@ var cnames_active = {
   "kst": "lucaelin.github.io/KST", // noCF
   "ktm": "developers-nepal.github.io/ktmjs",
   "kucos": "kucosjs.github.io",
-  "kumeru": "ultirequiem.github.io/kumeru"
+  "kumeru": "ultirequiem.github.io/kumeru",
   "kunal": "kunalghosh02.github.io",
   "kunkun": "smallkunkun.github.io",
   "kyoto": "kyotojs.github.io",

--- a/cnames_active.js
+++ b/cnames_active.js
@@ -2286,7 +2286,6 @@ var cnames_active = {
   "relate": "jakelazaroff.github.io/relate", // noCF? (don´t add this in a new PR)
   "relaunch": "pd4d10.github.io/relaunch",
   "relic": "relicjs.github.io",
-  "rema": "paramsiddharth.github.io/rema-docs",
   "remark": "remarkjs.github.io/remark",
   "remote-faces": "dai-shi.github.io/remote-faces",
   "rengular": "chigix.github.io/rengular",

--- a/ns_active.js
+++ b/ns_active.js
@@ -17,6 +17,7 @@ var ns_active = {
   "castyte": ["ns31.cloudns.net", "ns32.cloudns.net", "ns33.cloudns.net", "ns34.cloudns.net"],
   "engine262": ["brad.ns.cloudflare.com", "lia.ns.cloudflare.com"],
   "lolifamily": ["glen.ns.cloudflare.com", "melany.ns.cloudflare.com"],
+  "rema": ["crystal.ns.cloudflare.com", "justin.ns.cloudflare.com"],
   "ruby": ["alexis.ns.cloudflare.com", "connie.ns.cloudflare.com"],
   "samplasion": ["ns31.cloudns.net", "ns32.cloudns.net", "ns33.cloudns.net", "ns34.cloudns.net"],
   "shebang": ["dns1.p01.nsone.net", "dns2.p01.nsone.net", "dns3.p01.nsone.net", "dns4.p01.nsone.net"]


### PR DESCRIPTION
# Use Cloudflare for Rema
This update requests using Cloudflare nameservers for [rema.js.org](https://rema.js.org) instead of the regular CNAME.
This decision is made in regard to the growth of [Rema](https://github.com/paramsiddharth/rema) as a software project and other potential uses of the subdomain, such as:
- E-mail addresses.
- Sister documentation sites for Jugaadu Rema and other upcoming projects.
- Future plans for a fully ground-state SaaS with end-user abstractions.

- [x] There is reasonable content on the page (see: [No Content](https://github.com/js-org/js.org/wiki/No-Content))
- [x] I have read and accepted the [Terms and Conditions](http://js.org/terms.html)
