### PR TITLE
voidpage.js.org

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -3120,6 +3120,7 @@ var cnames_active = {
   "vlr": "vlrjs.github.io/website",
   "vncz": "xvincentx.github.io/vncz",
   "vocab": "battleofplassey.github.io/ministry-of-vocabulary",
+  "voidpage": "cname.vercel-dns.com", // noCF
   "volantis": "cname-china.vercel-dns.com", // noCF
   "volantis-x": "volantis-x.github.io",
   "voloshins": "voloshins.github.io", // noCF? (don´t add this in a new PR)


### PR DESCRIPTION
- [x] There is reasonable content on the page (see: [No Content](https://github.com/js-org/js.org/wiki/No-Content))
- [x] I have read and accepted the [Terms and Conditions](http://js.org/terms.html)

[Voidpage](https://voidpage-tau.vercel.app/) is a new tab extension for chrome that I am building. The extension is written in react, along with it's website. The repository for it is currently private and the extension is invite only, however I do plan to eventually open source it. I was going to just use the free `*.vercel.app` domain, however `voidpage.vercel.app` was already in use.

Thank you!
