### PR TITLE
feat: add rexskz.github.io/proto-message-helper

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -2251,6 +2251,7 @@ var cnames_active = {
   "projects-tracker": "iamdevlinph.github.io/projects-tracker",
   "propresenter": "thewilloftheshadow.github.io/propresenter",
   "proteic": "proteus-h2020.github.io/proteic",
+  "proto-message-helper": "rexskz.github.io/proto-message-helper",
   "proton": "jonathanzzero.github.io/proton",
   "proton-native": "kusti8.github.io/proton-native",
   "protonio": "aktilacengiz.github.io/protonio",


### PR DESCRIPTION
- [x] There is reasonable content on the page (see: [No Content](https://github.com/js-org/js.org/wiki/No-Content))
- [x] I have read and accepted the [Terms and Conditions](http://js.org/terms.html)

The proto-message-helper is a tool to help backend developers to inspect the protobuf message content.