### PR TITLE
ringo.js.org

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -2485,6 +2485,7 @@ var cnames_active = {
   "ricos": "wix.github.io/ricos",
   "riiickyy": "riiickyy.github.io",
   "riklewis": "riklewis.github.io",
+  "ringo": "cname.vercel-dns.com", // noCF
   "rinzler": "gitsquared.github.io/rinzler",
   "riot": "riot.github.io",
   "riotgear": "riotgear.github.io",


### PR DESCRIPTION
I want to get a `ringo.js.org` for my js project, here's the repo [akarachen/ringo](https://github.com/akarachen/ringo)

- [x] There is reasonable content on the page (see: [No Content](https://github.com/js-org/js.org/wiki/No-Content))
- [x] I have read and accepted the [Terms and Conditions](http://js.org/terms.html)
