### PR TITLE
connect.stacks.js.org

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -563,6 +563,7 @@ var cnames_active = {
   "confetti": "matteobruni.github.io/confetti",
   "conflict": "conflictjs.github.io/site",
   "conglo": "schwarzkopfb.github.io/conglo",
+  "connect.stacks": "cname.vercel-dns.com", // noCF
   "consent": "datamart.github.io/Consent",
   "consono": "r37r0m0d3l.github.io/consono",
   "construyendotrabajo": "mteyss.github.io/construyendotrabajo", // noCF? (don´t add this in a new PR)


### PR DESCRIPTION
- [x] There is reasonable content on the page (see: [No Content](https://github.com/js-org/js.org/wiki/No-Content))
- [x] I have read and accepted the [Terms and Conditions](http://js.org/terms.html)

---

## `connect.stacks.js.org`

`"stacks": "cname.vercel-dns.com", // noCF` has already existed for a while. This addition is a related library called `Stacks Connect` from the same team/org.

Live version: https://connect-stacks.vercel.app/
Related: https://stacks.js.org