### PR TITLE
catisol.js.org

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -1324,6 +1324,7 @@ var cnames_active = {
   "hyssop": "lillupad.github.io/hyssop.js",
   "i18n4v": "shibukawa.github.io/i18n4v",
   "iagrib": "iagrib.github.io",
+  "isolcat":"catisol.js.org",
   "iamsurajdc": "iamsurajdc.github.io",
   "icecast": "jucrouzet.github.io/icecast.js",
   "ices": "icesjs.github.io/ices",


### PR DESCRIPTION
I want to get a catisol.js.org for my js project, here's the repo [isolcat/CatIsol-UI](https://github.com/isolcat/CatIsol-UI)

 There is reasonable content on the page (see: [No Content](https://github.com/js-org/js.org/wiki/No-Content))
 I have read and accepted the [Terms and Conditions](http://js.org/terms.html)