### PR TITLE
catisol.js.org

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -1369,6 +1369,7 @@ var cnames_active = {
   "inline-style-prefixer": "rofrischmann.github.io/inline-style-prefixer",
   "innova": "innova-fll.github.io",
   "inscriptum": "sumbad.github.io/inscriptum",
+  "isolcat": "catisol-ui.netlify.app"
   "inset": "patlillis.github.io/inset.js",
   "insta": "androz2091.github.io/instajs-website",
   "instabousing": "jlbousing.github.io/instaBousing",


### PR DESCRIPTION
I want to get a catisol.js.org for my js project, here's the repo [isolcat/CatIsol-UIi](https://github.com/isolcat/CatIsol-UI)

 There is reasonable content on the page (see: [No Content](https://github.com/js-org/js.org/wiki/No-Content))
 I have read and accepted the [Terms and Conditions](http://js.org/terms.html)
