### PR TITLE
hashparser.js.org

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -1253,6 +1253,7 @@ var cnames_active = {
   "happy": "e24.github.io/happy", // noCF? (don´t add this in a new PR)
   "harry": "harry-yep.github.io",
   "hashchat": "hashchat-js.netlify.app",
+  "hashparser": "rvanbaalen.github.io/hashparser",
   "hasura-om": "mrspartak.github.io/hasura-om",
   "hay": "hayjs.github.io/hay.js.org",
   "hbase": "adaltas.github.io/node-hbase-docs",


### PR DESCRIPTION
HashParser is a tiny [npm package](https://www.npmjs.com/package/@rvanbaalen/hashparser) to get and set query parameters in the hash portion of an URL. It supports any value (string/number/array/object) and has basic support for encoding these values.

https://rvanbaalen.github.io/hashparser

- [x] There is reasonable content on the page (see: [No Content](https://github.com/js-org/js.org/wiki/No-Content))
- [x] I have read and accepted the [Terms and Conditions](http://js.org/terms.html)
