### PR TITLE
chalk.js.org

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -486,6 +486,7 @@ var cnames_active = {
   "chig": "eliotchignell.github.io",
   "chirashi": "chirashijs.github.io/chirashi",
   "chitchat": "chitchatjs.github.io",
+  "chalk": "bluefalconhd.github.io/chalk",
   "choo": "choo-js.github.io",
   "chordthing": "ifons42.github.io/chordthing",
   "chris": "christopher-hayes.github.io/chris",


### PR DESCRIPTION
repository url: https://github.com/BlueFalconHD/chalk/tree/main line number changed: 489

I made a small website that redirects to the chalk github page.

- [x] There is reasonable content on the page (see: [No Content](https://github.com/js-org/js.org/wiki/No-Content))
- [x] I have read and accepted the [Terms and Conditions](http://js.org/terms.html)
