### PR TITLE
macaron.js.org

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -1703,7 +1703,7 @@ var cnames_active = {
   "m01i0ng": "m01i0ng.github.io",
   "m8bot": "mapreiff.github.io/m8-bot-site",
   "ma124": "ma124.netlify.com",
-  "macaron": "macaron-css.github.io/macaron"
+  "macaron": "macaron-css.github.io/macaron",
   "machinelearning": "marink.github.io/machinelearning",
   "maclary": "maclary.github.io/maclary",
   "macosnotif": "mattipv4.github.io/macOSNotifJS",

--- a/cnames_active.js
+++ b/cnames_active.js
@@ -1703,6 +1703,7 @@ var cnames_active = {
   "m01i0ng": "m01i0ng.github.io",
   "m8bot": "mapreiff.github.io/m8-bot-site",
   "ma124": "ma124.netlify.com",
+  "macaron": "macaron-css.github.io/macaron"
   "machinelearning": "marink.github.io/machinelearning",
   "maclary": "maclary.github.io/maclary",
   "macosnotif": "mattipv4.github.io/macOSNotifJS",


### PR DESCRIPTION
Due to issue of relative paths with github pages the website might look unstyled right now, but once the domain is setup it should look like https://macaron-css.netlify.app.

- [x] There is reasonable content on the page (see: [No Content](https://github.com/js-org/js.org/wiki/No-Content))
- [x] I have read and accepted the [Terms and Conditions](http://js.org/terms.html)
