### PR TITLE
json-formatter.js.org

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -1479,7 +1479,6 @@ var cnames_active = {
   "jsoboro": "jsoboro.github.io",
   "json-diff-kit": "rexskz.github.io/json-diff-kit",
   "json-e": "json-e.github.io/json-e",
-  "json-formatter": "arnav-kr.github.io/json-formatter",
   "json-schema-faker": "json-schema-faker.github.io/website-jsf",
   "jsonapi": "ethanresnick.github.io/json-api",
   "jsoning": "khalby786.github.io/jsoning",


### PR DESCRIPTION
This removes the json-formatter.js.org subdomain because it does not point to the real JSON Formatter extension.

I created, own and maintain the **JSON Formatter** Chrome extension ([GitHub](https://github.com/callumlocke/json-formatter), [Chrome Web Store](https://chrome.google.com/webstore/detail/json-formatter/bcjindcccaagfpapjjmafapmmgkkhgoa?hl=en)). It has 1.8 million users and has been going since around 2012. It currently doesn't have a dedicated website.

The json-formatter.js.org subdomain currently points to a different Chrome extension ([GitHub](https://github.com/arnav-kr/json-formatter), [Chrome Web Store](https://chrome.google.com/webstore/detail/json-formatter/gpmodmeblccallcadopbcoeoejepgpnb)) that was created around 2021 and uses an identical name to mine, as well a having the same general look and feel. It's possible it was started as a fork from mine, which is fine. The issue is it uses the same name and makes no effort to differentiate itself from mine.

- [x] There is reasonable content on the page (see: [No Content](https://github.com/js-org/js.org/wiki/No-Content))
- [x] I have read and accepted the [Terms and Conditions](http://js.org/terms.html)
