### PR TITLE
domhandler.js.org

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -834,6 +834,7 @@ var cnames_active = {
   "dollar": "defims.github.io/dollar",
   "dolphin": "uyouthe.github.io/dolphin",
   "domainr": "cname.vercel-dns.com", // noCF
+  "domhandler": "fb55.github.io/domhandler",
   "dominion": "dominion-framework.github.io",
   "domiso": "un-ts.github.io/domiso",
   "domtastic": "webpro.github.io/DOMtastic",


### PR DESCRIPTION
- [x] There is reasonable content on the page (see: [No Content](https://github.com/js-org/js.org/wiki/No-Content))
- [x] I have read and accepted the [Terms and Conditions](http://js.org/terms.html)

I have set `domhandler.js.org` as the domain in the GitHub Pages settings, which makes the current site inaccessible (not sure how to add a CNAME file with the current setup). The deploy script is already active, and is deploying a TypeDoc-generated documentation website for https://github.com/fb55/domhandler. 