### PR TITLE
auth.js.org

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -240,6 +240,7 @@ var cnames_active = {
   "audio-stream": "guywhogeek.github.io/audio-stream",
   "aui": "alauda.github.io/alauda-ui",
   "autarky": "pranshuchittora.github.io/autarky",
+  "auth": "cname.vercel-dns.com", // noCF
   "auto-task-doc": "cname.vercel-dns.com", // noCF
   "autodocs": "bguiz.github.io/autodocs", // noCF? (don´t add this in a new PR)
   "automic": "automicjs.github.io",


### PR DESCRIPTION
We (NextAuth.js) have renamed to `Auth.js` and have our docs at a new domain `authjs.dev`.

We previously had (and still use) the `js.org` domain `next-auth.js.org`, and would like `auth.js.org` to redirect to the new one via Vercel as well.

Thanks!

- [x] There is reasonable content on the page (see: [No Content](https://github.com/js-org/js.org/wiki/No-Content))
- [x] I have read and accepted the [Terms and Conditions](http://js.org/terms.html)
