### PR TITLE
Add `easy.js.org` and `easyscript.js.org`

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -889,6 +889,7 @@ var cnames_active = {
   "eahmed234": "eahmed234.github.io",
   "ease": "chisel.github.io/ease",
   "easiermongo": "grook8958.github.io/easiermongo-docs",
+  "easy": "easyscriptjs.github.io/easy.js.org", // noCF
   "easy-bot": "bigaston.github.io/easy-bot",
   "easy-d": "easy-djs.github.io/easy-djs",
   "easy-enigma": "armoredvortex.github.io/easy-enigma",
@@ -896,6 +897,7 @@ var cnames_active = {
   "easyeyes": "easyeyes.github.io/website",
   "easyht": "yellowface233.github.io/easyht-website",
   "easypass": "cgluwxh.github.io/easypass",
+  "easyscript": "easyscriptjs.github.io/website", // noCF
   "easytrivia": "elitezen.github.io/easy-trivia-website",
   "easytrivia-guide": "turtlepaw.github.io/trivia-docs",
   "eatery-nod-w": "kevinast.github.io/eatery-nod-w",


### PR DESCRIPTION
- [x] There is reasonable content on the page (see: [No Content](https://github.com/js-org/js.org/wiki/No-Content))
- [x] I have read and accepted the [Terms and Conditions](http://js.org/terms.html)

`easy.js.org` will be used for short links for the project. e.g: easy.js.org/website will redirect to easyscript.js.org

`easyscript.js.org` will be used as the main website for the service.