### PR TITLE
aplayer-react.js.org

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -188,6 +188,7 @@ var cnames_active = {
   "apilyertia": "apilyertia.github.io",
   "aping": "johnnythetank.github.io/apiNG", // noCF? (don´t add this in a new PR)
   "aplayer": "diygod.github.io/APlayer",
+  "aplayer-react": "cname.vercel-dns.com", // noCF
   "apod": "marcosflorencio.github.io/angular-apod", // noCF? (don´t add this in a new PR)
   "applied": "omahajs.github.io/applied",
   "apprun": "yysun.github.io/apprun",


### PR DESCRIPTION
Hi, first of all thanks for this great service!

I've just deployed this docs site (currently only a demo page included) for my [`aplayer-react`](https://www.npmjs.com/package/aplayer-react) package at https://aplayer-react.vercel.app and want to cname `aplayer-react.js.org` to it. There seems to be no guide for cnaming to Vercel deployments, so I'm not sure whether this edit is correct. I just copied what `risingstar.js.org` is doing.

## Checklist

- [x] There is reasonable content on the page (see: [No Content](https://github.com/js-org/js.org/wiki/No-Content))
- [x] I have read and accepted the [Terms and Conditions](http://js.org/terms.html)
