### PR TITLE
confetti.js.org / particles.js.org

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -568,7 +568,7 @@ var cnames_active = {
   "concurrent-tasks": "hosting.gitbook.com",
   "concursos": "mteyss.github.io/concursos", // noCF? (don´t add this in a new PR)
   "conductor": "hosting.gitbook.com",
-  "confetti": "matteobruni.github.io/confetti",
+  "confetti": "tsparticles.github.io/confetti",
   "conflict": "conflictjs.github.io/site",
   "conglo": "schwarzkopfb.github.io/conglo",
   "connect.stacks": "cname.vercel-dns.com", // noCF
@@ -2164,7 +2164,7 @@ var cnames_active = {
   "parametric-svg": "parametric-svg.github.io", // noCF? (don´t add this in a new PR)
   "parkrun": "prouser123.github.io/parkrun.js",
   "parse5": "inikulin.github.io/parse5",
-  "particles": "matteobruni.github.io/tsparticles",
+  "particles": "tsparticles.github.io/website",
   "party": "yiliansource.github.io/party-js",
   "pas-ce-soir": "oldergod.github.io/pas-ce-soir",
   "passepartout": "falkz.github.io/passepartout.js.org",


### PR DESCRIPTION
- [x] There is reasonable content on the page (see: [No Content](https://github.com/js-org/js.org/wiki/No-Content))
- [x] I have read and accepted the [Terms and Conditions](http://js.org/terms.html)

The tsParticles urls are now on the @tsparticles organization in two different repositories:

- https://github.com/tsparticles/website for https://particles.js.org
- https://github.com/tsparticles/confetti for https://confetti.js.org

Instead of https://github.com/matteobruni/tsparticles and https://github.com/matteobruni/confetti repositories. As you can see, I'm still the author of the commits, in case of someone trying to change the ownership of the cnames.