### PR TITLE
sidekick.js.org

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -2690,6 +2690,7 @@ var cnames_active = {
   "shortio": "ichiidev.github.io/short.io-docs",
   "shuwan9": "shuwan9.github.io",
   "siddharth": "chaudhs769.github.io/siddharth.js.org",
+  "sidekick": "cname.vercel-dns.com", // noCF
   "sidekik": "inf3cti0n95.github.io/sidekik",
   "sidewind": "cname.vercel-dns.com", // noCF
   "sights": "sfxrescue.github.io/sights",


### PR DESCRIPTION
The current site exists at: [docs-sidekick.vercel.app](https://docs-sidekick.vercel.app).

It will be used to document a devtool for managing monorepos called sidekick. Source is on github here: [github.com/karimsa/sidekick](https://github.com/karimsa/sidekick) and it is published on npm under `@karimsa/sidekick`.

- [x] There is reasonable content on the page (see: [No Content](https://github.com/js-org/js.org/wiki/No-Content))
- [x] I have read and accepted the [Terms and Conditions](http://js.org/terms.html)
