### PR TITLE
cdb.js.org

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -464,7 +464,6 @@ var cnames_active = {
   "catisol": "catisol-ui.netlify.app",
   "cats": "whoisjorge.github.io/not-cat-gifs",
   "cbm": "cbmjs.github.io/cbm-website",
-  "cdb": "create-discord-bot.github.io",
   "cdc-bot": "cdc-bot-js-npm.github.io/website",
   "cdi": "kiprox.github.io/Candro-Drive-Index",
   "cdll": "cdll.github.io",


### PR DESCRIPTION
(Removal)
For some reason DocSearch wasn't crawling this subdomain so I'll have to return to github.io.

❤️ Thank you for the service!

- [x] There is reasonable content on the page (see: [No Content](https://github.com/js-org/js.org/wiki/No-Content))
- [x] I have read and accepted the [Terms and Conditions](http://js.org/terms.html)
