### PR TITLE
quickdb.js.org

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -2255,7 +2255,7 @@ var cnames_active = {
   "querybuilder": "mistic100.github.io/jQuery-QueryBuilder", // noCF? (don´t add this in a new PR)
   "quick": "d7b7ae5e1e-hosting.gitbook.io", // noCF
   "quick-crud": "kingrayhan.github.io/quick-crud",
-  "quickdb": "hosting.gitbook.com",
+  "quickdb": "plexidev.github.io/quick.db-docs",
   "quickerdb": "maniabots.github.io/QuickerDB",
   "quickmongo": "quickmongo.netlify.app",
   "quickpterodactyl": "condescending-haibt-c79013.netlify.app",


### PR DESCRIPTION
- [x] There is reasonable content on the page (see: [No Content](https://github.com/js-org/js.org/wiki/No-Content))
- [x] I have read and accepted the [Terms and Conditions](http://js.org/terms.html)

Trying to move from legacy GitBook to an Astro site through GitHub pages, new site should be available at: https://plexidev.github.io/quick.db-docs