### PR TITLE
poru.js.org

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -2213,6 +2213,7 @@ var cnames_active = {
   "post-type-discovery": "twozeroone.github.io/post-type-discovery",
   "postlit": "postlit.github.io/postlit.js-site",
   "potion": "finnfiddle.github.io/potion",
+  "poru": "poru.vercel.app",
   "pp": "promptpay.github.io",
   "pplayer": "m4tec.github.io/PenguinPlayer",
   "ppt": "1ocalhost.github.io/ppt",


### PR DESCRIPTION
Add poru.js.org. this site will be used as the docs for https://github.com/parasop/poru