### PR TITLE
aesthetic.js.org

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -100,6 +100,7 @@ var cnames_active = {
   "adv": "advjs.github.io",
   "advancedrpc": "advancedrpc.github.io",
   "aeon": "flazepe.github.io/aeon-web",
+  "aesthetic": "esthetic-docs.netlify.app",
   "affiliate": "russellsteadman.github.io/affiliate",
   "afilters": "dmytrohoi.github.io/afilters.js",
   "afmsavage": "afmsavage.github.io",


### PR DESCRIPTION
- [x] There is reasonable content on the page (see: [No Content](https://github.com/js-org/js.org/wiki/No-Content))
- [x] I have read and accepted the [Terms and Conditions](http://js.org/terms.html)

---

This currently lives on https://æsthetic.dev but due to latin letters the domain renders as `https://xn--sthetic-lxa.dev` which is problematic. Leveraging a `.js.org` address would help here. Thanks.

**Content**

- https://esthetic-docs.netlify.app
- https://esthetic-docs.netlify.app/introduction/what-is-esthetic/


