### PR TITLE
speedybot.js.org / speedybot-mini.js.org

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -2711,7 +2711,7 @@ var cnames_active = {
   "spark-handler": "cname.vercel-dns.com", // noCF
   "spax": "crossjs.github.io/spax-site",
   "spectragram": "adrianengine.github.io/jquery-spectragram", // noCF? (don´t add this in a new PR)
-  "speedybot-mini": "valgaze.github.io/speedybot-mini",
+  "speedybot": "valgaze.github.io/speedybot",
   "speroxu": "speroxu.github.io",
   "spider": "spider-scraper.netlify.app",
   "spike": "spike.netlify.com",


### PR DESCRIPTION
Add speedybot.js.org, remove speedybot-mini.js.org:

- [x] There is reasonable content on the page (see: [No Content](https://github.com/js-org/js.org/wiki/No-Content))
- [x] I have read and accepted the [Terms and Conditions](http://js.org/terms.html)
- [x] I have added a CNAME file to my repo: **[https://github.com/valgaze/speedybot/blob/master/CNAME](https://github.com/valgaze/speedybot/blob/master/CNAME)**

Content: https://github.com/valgaze/speedybot/blob/master/index.html#L1
Site: http://valgaze.github.io/speedybot