### PR TITLE
Added 'rx' CNAME entry pointing to iaseth.github.io/readmix

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -2515,6 +2515,7 @@ var cnames_active = {
   "rut": "jeam.github.io/rut",
   "ruwan": "rpgee.github.io",
   "rva": "fanyer.github.io/rva",
+  "rx": "iaseth.github.io/readmix",
   "ryaneldon": "ry-e.github.io",
   "s3swa": "s3swa-ict-upgifter.github.io/snow-eater",
   "s4swa": "s4swa.github.io",


### PR DESCRIPTION
Readmix is a markdown/HTML/PDF? generator that allows you to write JavaScript in markdown. The readmix cli is available at https://www.npmjs.com/package/readmix. I am using 'rx' instead of 'readmix' for the subdomain because 'rx' is the file extension used by readmix templates, and it is shorter then the fullname of the repo.

- [x] There is reasonable content on the page (see: [No Content](https://github.com/js-org/js.org/wiki/No-Content))
- [x] I have read and accepted the [Terms and Conditions](http://js.org/terms.html)
