### PR TITLE
wellington.js.org

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -3196,7 +3196,6 @@ var cnames_active = {
   "wedgetail": "wedgetail.netlify.com",
   "weekly": "xdimh.github.io/weekly",
   "welcome": "edapm.github.io/welcomejs",
-  "wellington": "wellington-js.github.io/website",
   "wepl": "obnoxiousnerd.github.io/wepl-website",
   "wfplayer": "zhw2590582.github.io/WFPlayer",
   "wglt": "codyebberson.github.io/wglt",


### PR DESCRIPTION
I've made this PR to remove `wellington` from the CNAMEs list. I originally added it in a previous PR, but as I've deleted the repository behind that GitHub Pages deployment, there is nothing there anymore - it just returns a 404.

- [ ] There is reasonable content on the page (see: [No Content](https://github.com/js-org/js.org/wiki/No-Content))
- [x] I have read and accepted the [Terms and Conditions](http://js.org/terms.html)
