### PR TITLE
cut.js.org

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -636,6 +636,7 @@ var cnames_active = {
   "curseapp": "mcrocks999.github.io/curseapp.js",
   "custard": "custard-pkg.github.io",
   "custom-captcha": "mcnagynorbi.github.io/custom-captcha",
+  "cut": "dscc.cf",
   "cville": "cvjs.github.io",
   "cvss": "cvssjs.github.io",
   "cy-rn": "tyrone2333.github.io/cy-react-native-cli",


### PR DESCRIPTION
added 
"cut: "dscc.cf",

- [x] There is reasonable content on the page (see: [No Content](https://github.com/js-org/js.org/wiki/No-Content))
- [x] I have read and accepted the [Terms and Conditions](http://js.org/terms.html)
Link shortener, written with Javascript
Hosted on replit, not github (ive created the cname request on replit's panel
Important: replit says me to insert the CNAME record as "cut.js.org CNAME dscc.cf" since i already have a domain named "dscc.cf"