### PR TITLE
pronouns.js.org

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -2253,6 +2253,7 @@ var cnames_active = {
   "program-builder": "program-builder.netlify.com",
   "progressbars": "josephabbey.github.io/progressbars",
   "projects-tracker": "iamdevlinph.github.io/projects-tracker",
+  "pronouns": "8f0bc99f-d5a9-410d-9429-8b031e9a7b0c.id.repl.co",
   "propresenter": "thewilloftheshadow.github.io/propresenter",
   "proteic": "proteus-h2020.github.io/proteic",
   "proto-message-helper": "rexskz.github.io/proto-message-helper",


### PR DESCRIPTION
Added `8f0bc99f-d5a9-410d-9429-8b031e9a7b0c.id.repl.co` with subdomain `pronouns`

- [x] There is reasonable content on the page (see: [No Content](https://github.com/js-org/js.org/wiki/No-Content))
- [x] I have read and accepted the [Terms and Conditions](http://js.org/terms.html)
