### PR TITLE
dgs-docs.js.org

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -726,6 +726,7 @@ var cnames_active = {
   "devlunch": "superzackx.github.io/DevLunch",
   "devsession": "lukasbach.github.io/devsession",
   "dgelong": "alexeyraspopov.github.io/dgelong", // noCF? (don´t add this in a new PR)
+  "dgs-docs": "shadowplay1.github.io/discord-giveaways-super",
   "dhimasanb": "dhimasanb.github.io",
   "dhruvdutt": "dhruvdutt.github.io",
   "diamond": "diamondpkg.github.io/website",


### PR DESCRIPTION
- [x] There is reasonable content on the page (see: [No Content](https://github.com/js-org/js.org/wiki/No-Content))
- [x] I have read and accepted the [Terms and Conditions](http://js.org/terms.html)

this is a documentation website for the upcoming `discord-giveaways-super` package, main page of the docs website opens with no problems, however, with bad domain (https://shadowplay1.github.io/discord-giveaways-super) the "documentation" section refuses to work no matter how hard i tried to make it work, it works fine if launching on localhost or on any domain without anything after it (for example, it would work on `http://localhost:(port)`, or `dgs-docs.js.org`, beacause the link path is empty, and it wont work on `https://shadowplay1.github.io/discord-giveaways-super` because the link path is not empty and includes `discord-giveaways-super`)

thanks for understanding :)

if needed, i can provide screenshots of the "documentation" section working on localhost