### PR TITLE
kita.js.org

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -1533,8 +1533,8 @@ var cnames_active = {
   "kimera": "ultirequiem.github.io/kimera",
   "kindavishal": "kindavishal.netlify.com",
   "kiranremmarasu": "kiranremmarasu.github.io/kiranremmarasu",
-  "kite": "kite-js.github.io/kite",
   "kita": "kitajs.github.io/docs",
+  "kite": "kite-js.github.io/kite",
   "kiwidocs": "arguiot.github.io/KiwiDocs",
   "kkapi": "cname.vercel-dns.com", // noCF
   "klasa": "dirigeants.github.io/klasa-website",

--- a/cnames_active.js
+++ b/cnames_active.js
@@ -1534,6 +1534,7 @@ var cnames_active = {
   "kindavishal": "kindavishal.netlify.com",
   "kiranremmarasu": "kiranremmarasu.github.io/kiranremmarasu",
   "kite": "kite-js.github.io/kite",
+  "kita": "kitajs.github.io/docs",
   "kiwidocs": "arguiot.github.io/KiwiDocs",
   "kkapi": "cname.vercel-dns.com", // noCF
   "klasa": "dirigeants.github.io/klasa-website",


### PR DESCRIPTION
- [x] There is reasonable content on the page (see: [No Content](https://github.com/js-org/js.org/wiki/No-Content))
- [x] I have read and accepted the [Terms and Conditions](http://js.org/terms.html)

## Kita JS

> Performant and type safe Fastify router -- Build fast end-to-end APIs with ZERO abstraction cost!

Current documentation still being done. However, product (https://github.com/kitajs/kitajs) is already working and used in production. Waiting approval here to commit CNAME and after finished I'll have to fix current base path to remove the `/docs` GitHub pages default.

Thanks!