### PR TITLE
doars.js.org / hoast.js.org

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -822,6 +822,7 @@ var cnames_active = {
   "dls-docs": "shadowplay1.github.io/dls-docs",
   "dmitry": "dmitry-zaets.github.io",
   "dna": "dna-engine.github.io/dna-engine",
+  "doars": "doars.github.io",
   "docile": "russellsteadman.github.io/docile",
   "docs.guildedts": "guildedts.github.io/docs", // noCF
   "docs.light": "hosting.gitbook.com", // noCF
@@ -1301,6 +1302,7 @@ var cnames_active = {
   "hltvbot": "nescabir.github.io/HLTVBot",
   "hmsscioly": "scioly.netlify.app",
   "hoa": "thehoa.github.io",
+  "hoast": "hoast.github.io"
   "hois": "hoisw.github.io",
   "holidaycss": "evgenyorekhov.github.io/holiday.css",
   "hooked-on-redux": "harryhope.github.io/hooked-on-redux",

--- a/cnames_active.js
+++ b/cnames_active.js
@@ -1302,7 +1302,7 @@ var cnames_active = {
   "hltvbot": "nescabir.github.io/HLTVBot",
   "hmsscioly": "scioly.netlify.app",
   "hoa": "thehoa.github.io",
-  "hoast": "hoast.github.io"
+  "hoast": "hoast.github.io",
   "hois": "hoisw.github.io",
   "holidaycss": "evgenyorekhov.github.io/holiday.css",
   "hooked-on-redux": "harryhope.github.io/hooked-on-redux",


### PR DESCRIPTION
Added doars (doars.github.io) and hoast (hoast.github.io)

CNAME file for doars: https://github.com/doars/doars/blob/main/docs/CNAME
CNAME file for hoast: https://github.com/hoast/hoast/blob/main/docs/CNAME

Both websites are webpages for javascript libraries written and maintained by me. One a front-end framework for the browser, the other a data processor for Node.

- [x] There is reasonable content on the page (see: [No Content](https://github.com/js-org/js.org/wiki/No-Content))
- [x] I have read and accepted the [Terms and Conditions](http://js.org/terms.html)

