### PR TITLE
craft.js.org

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -630,7 +630,7 @@ var cnames_active = {
   "crackabottle": "crack-a-bottle.github.io",
   "cracked": "billorcutt.github.io/Cracked",
   "craco": "dilanx.github.io/craco",
-  "craft": "craftjs.netlify.app",
+  "craft": "cname.vercel-dns.com", // noCF
   "crank": "bikeshaving.github.io/crank",
   "crawlx": "wind2sing.github.io/crawlx",
   "crawlyx": "theritikchoure.github.io/crawlyx",


### PR DESCRIPTION
Move craft.js.org from craftjs.netlify.app to craftjs.vercel.app

- [x] There is reasonable content on the page (see: [No Content](https://github.com/js-org/js.org/wiki/No-Content))
- [x] I have read and accepted the [Terms and Conditions](http://js.org/terms.html)
