### PR TITLE
moloko.js.org / aesthetic.js.org

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -101,6 +101,7 @@ var cnames_active = {
   "adon988": "adon988.github.io",
   "adv": "advjs.github.io",
   "advancedrpc": "advancedrpc.github.io",
+  "aesthetic": "esthetic-docs.netlify.app",
   "aeon": "flazepe.github.io/aeon-web",
   "aerogel": "noeldemartin.github.io/aerogel",
   "affiliate": "russellsteadman.github.io/affiliate",
@@ -1917,6 +1918,7 @@ var cnames_active = {
   "mojiscript": "joelnet.github.io/MojiScript",
   "mokunshao": "mokunshao.github.io",
   "mol": "eigenmethod.github.io/mol", // noCF
+  "moloko": "molokojs.netlify.app",
   "molti": "moltijs.github.io/molti",
   "mom": "momjs.github.io/mom",
   "momentum": "wemakeweb.github.io/momentum", // noCF? (don´t add this in a new PR)


### PR DESCRIPTION
- [x] There is reasonable content on the page (see: [No Content](https://github.com/js-org/js.org/wiki/No-Content))
- [x] I have read and accepted the [Terms and Conditions](http://js.org/terms.html)

Hi guys, 

I'm adding in two additions here. I've previously tried to submit `aesthetic` and never got back in the PR as I had some personal issues. (see: https://github.com/js-org/js.org/pull/8159). As the current domain is set to expire, it will default to to the `.js.org` suffix as per your request. 

The other addition meets all requirements. 

Thanks