### PR TITLE
Move kita.js.org to vercel CNAME.

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -1556,7 +1556,7 @@ var cnames_active = {
   "kimera": "ultirequiem.github.io/kimera",
   "kindavishal": "kindavishal.netlify.app",
   "kiranremmarasu": "kiranremmarasu.github.io/kiranremmarasu",
-  "kita": "kitajs.github.io/docs",
+  "kita": "cname.vercel-dns.com", // noCF
   "kite": "kite-js.github.io/kite",
   "kiwidocs": "arguiot.github.io/KiwiDocs",
   "kkapi": "cname.vercel-dns.com", // noCF


### PR DESCRIPTION
I looked up older issues and saw that I should add `// noCF` too, is that right?

- [x] There is reasonable content on the page (see: [No Content](https://github.com/js-org/js.org/wiki/No-Content))
- [x] I have read and accepted the [Terms and Conditions](http://js.org/terms.html)
