### PR TITLE
rema.js.org

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -2530,7 +2530,7 @@ var cnames_active = {
   "relate": "jakelazaroff.github.io/relate", // noCF? (don´t add this in a new PR)
   "relaunch": "pd4d10.github.io/relaunch",
   "relic": "relicjs.github.io",
-  "rema": "paramsiddharth.github.io/rema-docs",
+  "rema": "heyrema.github.io/docs",
   "remark": "remarkjs.github.io/remark",
   "remote-faces": "dai-shi.github.io/remote-faces",
   "rengular": "chigix.github.io/rengular",


### PR DESCRIPTION
Rema is being relocated from my personal profile to a dedicated GitHub organization. Hence, updating the CNAME URL.

- [x] There is reasonable content on the page (see: [No Content](https://github.com/js-org/js.org/wiki/No-Content))
- [x] I have read and accepted the [Terms and Conditions](http://js.org/terms.html)
