### PR TITLE
embedded.js.org

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -954,6 +954,7 @@ var cnames_active = {
   "emage": "douglasjunior.github.io/emage",
   "email-templates": "niftylettuce.github.io/email-templates",
   "embarrassed-themes": "kbothub.github.io/Embarrassed-Themes",
+  "embedded": "ecmatc53.github.io/docs",
   "embedlam": "wnda.github.io/embedlam",
   "ember": "ember-learn.github.io/ember-js-org",
   "ember-cli-page-object": "san650.github.io/ember-cli-page-object", // noCF? (don´t add this in a new PR)


### PR DESCRIPTION
- [x] There is reasonable content on the page (see: [No Content](https://github.com/js-org/js.org/wiki/No-Content))
- [x] I have read and accepted the [Terms and Conditions](http://js.org/terms.html)

Repo: https://github.com/EcmaTC53/docs
The CNAME file is in the `public/` directory at the root of the repository as documented by Astro: https://docs.astro.build/en/guides/deploy/github/
The domain is also set in the GitHub Pages settings for the repo. 