### PR TITLE
bettertests.js.org

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -329,7 +329,7 @@ var cnames_active = {
   "besafe": "ma124.github.io/BeSafe",
   "bestlist": "andrelucaas.github.io/bestlist",
   "bestof": "michaelrambeau.github.io/bestofjs",
-  "bettertests": "bettertests.github.io",
+  "bettertests": "antgonzales.github.io/bettertests.js.org",
   "between": "na-west1.surge.sh",
   "bfd": "mrsheldon.github.io/bfd.js",
   "bhailang": "dullabs.github.io/bhai-lang",


### PR DESCRIPTION
Change of ownership for the Better Tests project currently live at [bettertests.js.org](https://bettertests.js.org/).

- [x] There is reasonable content on the page (see: [antgonzales/bettertests.js.org](https://github.com/antgonzales/bettertests.js.org))
- [x] I have read and accepted the [Terms and Conditions](http://js.org/terms.html)
