### PR TITLE
jiejaitt.js.org

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -1493,7 +1493,6 @@ var cnames_active = {
   "jessm": "jessi-mhernandez.github.io/JessicaM",
   "jetaimetantquetuestoi": "dakokonutboi.github.io/jetaimetantquetuestoi",
   "jets": "nexts.github.io/Jets.js",
-  "jiejaitt": "jiejaitt.github.io",
   "jinada": "redsplit.github.io/jinada",
   "jjlc": "k-yak.github.io/JJLC", // noCF? (don´t add this in a new PR)
   "jk": "joname1.github.io",


### PR DESCRIPTION
Remove jiejaitt.js.org

Thank you for the service and work you have provided, but I have already migrated the documentation to Vercel. Therefore, I am submitting this pull request to remove the unused domain.

- [x] There is reasonable content on the page (see: [No Content](https://github.com/js-org/js.org/wiki/No-Content))
- [x] I have read and accepted the [Terms and Conditions](http://js.org/terms.html)
