### PR TITLE
jscdn.js.org

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -1523,6 +1523,7 @@ var cnames_active = {
   "jparticles": "jparticles.github.io/Documentation",
   "js-fixerr": "anujsinghwd.github.io/js-fixerr",
   "js-labs": "cname.vercel-dns.com", // noCF
+  "jscdn": "bi.netlify.app", // noCF
   "jscord": "thepoptartcrpr.github.io/jscord",
   "jsdec": "liulihaocai.github.io/JSDec",
   "jsfe": "jsfe.netlify.app",


### PR DESCRIPTION
- [x] There is reasonable content on the page (see: [No Content](https://github.com/js-org/js.org/wiki/No-Content))
- [x] I have read and accepted the [Terms and Conditions](http://js.org/terms.html)
This is my second time submitting a request. I apologize for any misunderstanding that may have occurred due to the language barrier. Unfortunately, jsDelivr does not currently have a CDN node in China, resulting in slow loading speeds for Chinese users. This poses significant inconvenience for Chinese application developers who rely on jsDelivr resources, as well as confusion for website users who experience delays of 5 seconds or more when loading jsDelivr's assets. To address this issue, our service acts as a reverse proxy for jsDelivr through vercel and utilizes CDN nodes located in China (such as Beijing, Shanghai, Tianjin) to improve loading speeds. Many Chinese developers have already integrated our service into their websites, with nearly 10,000 websites utilizing our services by 2023. Although this number is small compared to jsDelivr's user base, we are proud to offer this personalized solution! We now require a domain name to promote our service and provide instructions on how to use it and refresh cache effectively. We hope you approve of these changes.

Project preview: https://bi.netlify.app/