### PR TITLE
aries.js.org / credo.js.org

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -218,6 +218,7 @@ var cnames_active = {
   "ari": "arbo77.github.io/ari",
   "ariang": "p3terx.github.io/ariang", // noCF
   "arief": "1997arief.github.io",
+  "aries": "timoglastra.github.io/aries-credo-redirect",
   "arime": "ninbryan.github.io/arime", // noCF? (don´t add this in a new PR)
   "arithmy": "arithmy.netlify.app",
   "arshad": "arshadmhabib.github.io",

--- a/cnames_active.js
+++ b/cnames_active.js
@@ -218,7 +218,6 @@ var cnames_active = {
   "ari": "arbo77.github.io/ari",
   "ariang": "p3terx.github.io/ariang", // noCF
   "arief": "1997arief.github.io",
-  "aries": "hyperledger.github.io/aries-javascript-docs",
   "arime": "ninbryan.github.io/arime", // noCF? (don´t add this in a new PR)
   "arithmy": "arithmy.netlify.app",
   "arshad": "arshadmhabib.github.io",
@@ -654,6 +653,7 @@ var cnames_active = {
   "create-project": "chalarangelo.github.io/create-js-project",
   "createrest": "atomixinteractions.github.io/createrest",
   "creaturegen": "ryancromebook.github.io/creaturegen",
+  "credo": "openwallet-foundation.github.io/credo-ts-docs",
   "crls": "lukecarr.github.io/crls",
   "crossani": "cname.vercel-dns.com", // noCF
   "crossbell": "crossbell-box.github.io/crossbell.js",


### PR DESCRIPTION
- [x] There is reasonable content on the page (see: [No Content](https://github.com/js-org/js.org/wiki/No-Content))
- [x] I have read and accepted the [Terms and Conditions](http://js.org/terms.html)

We have moved the project docs hosted under `aries.js.org` to a new organization (from `hyperledger` to `openwallet-foundation`), and are also in the process of renaming the project to `credo` so we'd like to update the `aries.js.org` to `credo.js.org`

It's not ready to be merged yet (as we're in the process of renaming still), but I had a few questions with this move:
1. Can we redirect `aries.js.org` to `credo.js.org` or is that not possible?
2. Do we somehow need to verify the account ownership? The original PR for `aries.js.org` was also created by me (see https://github.com/js-org/js.org/pull/7347), and you can verify the move of organization by going to https://github.com/hyperledger/aries-javascript-docs and seeing you're redirect to https://github.com/openwallet-foundation/agent-javascript-docs (where a [CNAME PR](https://github.com/openwallet-foundation/agent-javascript-docs/pull/141) is opened by me, we will rename the repo to `credo-ts-docs` and merge that PR before this one should be merged)

