### PR TITLE
Update addGitHubPage.md

### DIFF
--- a/PULL_REQUEST_TEMPLATE/addGitHubPage.md
+++ b/PULL_REQUEST_TEMPLATE/addGitHubPage.md
@@ -1,3 +1,3 @@
 - [x] I have read and accepted the [Terms and Conditions](http://js.org/terms.html)
 - [x] There is reasonable content on the page
-- [x] I have added a CNAME file to my repo: ***[insert URL here]***
+- [x] I have added a CNAME file to my repo: ***[https://webkrafters.github.io/eagleeye/]***


### PR DESCRIPTION
Request to add subdomain for react context state manager "eagle eye" docs to the list of existing JS.ORG domains.

- [x] There is reasonable content on the page (see: [No Content](https://github.com/js-org/js.org/wiki/No-Content))
- [x] I have read and accepted the [Terms and Conditions](http://js.org/terms.html)
