### PR TITLE
f1.js.org

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -1052,6 +1052,7 @@ var cnames_active = {
   "extenso": "theuves.github.io/extenso.js.org",
   "extraction": "rse.github.io/extraction", // noCF? (don´t add this in a new PR)
   "eye": "arguiot.github.io/EyeJS",
+  "f1": "marinofranz.github.io/f1.ts",
   "faceapp": "negarang.github.io/face-app",
   "facepalm": "santiagogil.github.io/facepalm",
   "facreative": "facreative.github.io",


### PR DESCRIPTION
[`f1.ts`](https://www.npmjs.com/package/f1.ts) is an NPM package to interact with a Formula 1 API, designed with TypeScript compatibility in mind.

I couldn't publish to NPM as `f1.js` as it was too similar to `f1js`, so I'm hoping there can be an exception made to shorten the subdomain to `f1.js.org`.

The site is hosted under the [`gh-pages`](https://github.com/marinofranz/f1.ts/tree/gh-pages) branch and contains documentation for the package.

I've already set up the CNAME file, so it automatically redirects to `f1.js.org` but I'll insert a screenshot below to provide a preview as to what the site looks like in its current state.

![image](https://github.com/js-org/js.org/assets/48334228/c20572bb-133a-479b-a38f-d3065572715a)

- [x] There is reasonable content on the page (see: [No Content](https://github.com/js-org/js.org/wiki/No-Content))
- [x] I have read and accepted the [Terms and Conditions](http://js.org/terms.html)
