### PR TITLE
rebornxp.js.org

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -2543,7 +2543,7 @@ var cnames_active = {
   "reatom": "artalar.github.io/reatom",
   "rebatov": "rebatov.github.io",
   "rebem": "rebem.github.io", // noCF? (don´t add this in a new PR)
-  "rebornxp": "rebornxp.github.io/rebornxp",
+  "rebornxp": "rebornxp.netlify.app",
   "reciple": "cname.vercel-dns.com", // noCF
   "recover": "luisvallejomohl.github.io/Recover.js",
   "recycle": "recyclejs.github.io/recycle",


### PR DESCRIPTION
Production is moved to netlify instead of gh-pages, please update the CNAME. The repository remains the same.

- [x] There is reasonable content on the page (see: [No Content](https://github.com/js-org/js.org/wiki/No-Content))
- [x] I have read and accepted the [Terms and Conditions](http://js.org/terms.html)
