### PR TITLE
 botui-cn.js.org

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -387,7 +387,6 @@ var cnames_active = {
   "botgram": "botgram.github.io/botgram",
   "bottender": "yoctol.github.io/bottender",
   "bottlecap": "rwbeast.github.io/bottlecap",
-  "botui-cn": "botui-docs-cn.netlify.app",
   "boundless": "enigma-io.github.io/boundless",
   "box": "capacitorset.github.io/box-js", // noCF
   "boxed": "lionking27.github.io/boxed",


### PR DESCRIPTION
Remove botui-cn.js.org

Thank you for the service and valuable contributions you've provided. However, since the site has not been actively maintained for an extended period and may contain potential issues, I have recently archived the repo. So, I am submitting this pull request to remove the domain.

- [x] There is reasonable content on the page (see: [No Content](https://github.com/js-org/js.org/wiki/No-Content))
- [x] I have read and accepted the [Terms and Conditions](http://js.org/terms.html)
