### PR TITLE
storybook-test.js.org

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -3012,6 +3012,7 @@ var cnames_active = {
   "storelocator": "storelocatorjs.github.io",
   "story": "alltobebetter.github.io/story",
   "storybook": "storybooks.netlify.app", // noCF
+  "storybook-test": "cname.vercel-dns.com", // noCF
   "storybooks": "storybooks.github.io",
   "str": "manelet.github.io/str",
   "stratic": "straticjs.github.io",


### PR DESCRIPTION
- [x] There is reasonable content on the page (see: [No Content](https://github.com/js-org/js.org/wiki/No-Content))
- [x] I have read and accepted the [Terms and Conditions](http://js.org/terms.html)

We're migrating from Netlify to Vercel and this change is to test it's properly setup before we do the real move. After we verify the changes, I plan to submit a second PR deleting this entry and updating the `storybook.js.org` entry.

Content: https://storybookjs.vercel.app/

Thanks, as always, for this wonderful service!! 🙏 