### PR TITLE
Fix apostrophe in cnames_active comment

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -34,7 +34,7 @@
  *              order. Each line apart from the very last entry should have a comma after it to ensure this file
  *              is valid syntax.
  *
- *              BECAUSE OF THE RISK OF ABUSE, I´M NOT ACCEPTING REQUESTS FOR PAGES WITHOUT REASONABLE CONTENT!
+ *              BECAUSE OF THE RISK OF ABUSE, I'M NOT ACCEPTING REQUESTS FOR PAGES WITHOUT REASONABLE CONTENT!
  */
 
 var cnames_active = {


### PR DESCRIPTION
' is the proper character here.
Sorry to be mean but I figured I wasn't harming anyone by suggesting this little change :)