### PR TITLE
discord-components.js.org

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -797,6 +797,7 @@ var cnames_active = {
   "discord-botlists": "sidisliveyt.github.io/discord-botlists",
   "discord-button-page": "kingofpanda-development.github.io/discord-button-page",
   "discord-cmds": "hosting.gitbook.io", // noCF
+  "discord-components": "skyra-project.github.io/discord-components",
   "discord-console-logger": "lucaslah.github.io/discord-console-logger",
   "discord-easy-leveling": "retrouser955.github.io/discord-easy-leveling",
   "discord-easy-slash": "amukh1.github.io/discord-easy-slash",


### PR DESCRIPTION
- [x] There is reasonable content on the page (see: [No Content](https://github.com/js-org/js.org/wiki/No-Content))
- [x] I have read and accepted the [Terms and Conditions](http://js.org/terms.html)

> [!NOTE]
> 1. In case maintainers are looking for the CNAME file, it is located here: https://github.com/skyra-project/discord-components/blob/main/docs/public/CNAME
> 2. I am aware that styles and scripts are currently not loading on https://skyra-project.github.io/discord-components/, this will be fixed once we're granted the domain as it relies on Vite configuration. Currently the `base` is already set to `/`, ahead of getting the domain, as opposed to `/discord-components/` which it should be for GitHub pages.)
