### PR TITLE
leetcode.js.org

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -1713,6 +1713,7 @@ var cnames_active = {
   "leeks": "ohlookitsderpy.github.io/leeks.js",
   "leet": "leetcodes.github.io",
   "leet-xt": "binbard.github.io/leet-xt",
+  "leetcode": "cname.vercel-dns.com", // noCF
   "legendz": "botstudios.github.io/LEGENDZ",
   "lego": "polight.github.io/lego",
   "leipzig": "leipzigjs.github.io", // noCF? (don´t add this in a new PR)


### PR DESCRIPTION
- [x] There is reasonable content on the page (see: [No Content](https://github.com/js-org/js.org/wiki/No-Content))
- [x] I have read and accepted the [Terms and Conditions](http://js.org/terms.html)

Note: 
I noticed that `leet.js.org` was broken, so I added this new link. The cname original link is: javascript-leetcode.vercel.app.
