### PR TITLE
brazil.js.org

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -399,9 +399,9 @@ var cnames_active = {
   "brandifyjs": "greybax.github.io/brandifyjs",
   "brandonmerritt": "brandonmerritt.github.io", // noCF? (don´t add this in a new PR)
   "brasil": "javascriptbrasil.github.io",
-  "brazil": "https://braziljs.github.io/2025-conf/",
   "brawley": "brawlie.github.io/brawley",
   "brawlstats": "brawlstatsjs.netlify.app",
+  "brazil": "braziljs.github.io/2025-conf/",
   "breadbot": "centralomd.github.io/breadbot",
   "brick-next": "easyops-cn.github.io/brick-next",
   "bricklayer": "ademilter.github.io/bricklayer", // noCF? (don´t add this in a new PR)

--- a/cnames_active.js
+++ b/cnames_active.js
@@ -399,6 +399,7 @@ var cnames_active = {
   "brandifyjs": "greybax.github.io/brandifyjs",
   "brandonmerritt": "brandonmerritt.github.io", // noCF? (don´t add this in a new PR)
   "brasil": "javascriptbrasil.github.io",
+  "brazil": "https://braziljs.github.io/2025-conf/",
   "brawley": "brawlie.github.io/brawley",
   "brawlstats": "brawlstatsjs.netlify.app",
   "breadbot": "centralomd.github.io/breadbot",

--- a/cnames_active.js
+++ b/cnames_active.js
@@ -401,7 +401,7 @@ var cnames_active = {
   "brasil": "javascriptbrasil.github.io",
   "brawley": "brawlie.github.io/brawley",
   "brawlstats": "brawlstatsjs.netlify.app",
-  "brazil": "braziljs.github.io/2025-conf/",
+  "brazil": "braziljs.github.io/2025-conf",
   "breadbot": "centralomd.github.io/breadbot",
   "brick-next": "easyops-cn.github.io/brick-next",
   "bricklayer": "ademilter.github.io/bricklayer", // noCF? (don´t add this in a new PR)


### PR DESCRIPTION
Added the reference to BrazilJS.
We have the main BrazilJS portal at braziljs.org and channel at youtube.com/braziljs. But the braziljs conference is always at conf.braziljs.org and we would love to see the current/next conference always in brazil.js.org :)

- [x] There is reasonable content on the page (see: [No Content](https://github.com/js-org/js.org/wiki/No-Content))
- [x] I have read and accepted the [Terms and Conditions](http://js.org/terms.html)
