### PR TITLE
shuffle.js.org

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -2880,6 +2880,7 @@ var cnames_active = {
   "shortener": "jsmiith.github.io/shortener",
   "shortio": "ichiidev.github.io/short.io-docs",
   "shrimple": "shrimplejs.github.io",
+  "shuffle": "vestride.github.io/Shuffle",
   "shuwan9": "shuwan9.github.io",
   "siddharth": "chaudhs769.github.io/siddharth.js.org",
   "sidekick": "cname.vercel-dns.com", // noCF


### PR DESCRIPTION
Project: https://github.com/Vestride/Shuffle

Package: https://www.npmjs.com/package/shufflejs

I just added the cname to docusaurus and changed the base url, so the docs site is kinda broken-looking right now: https://vestride.github.io/Shuffle/

- [x] There is reasonable content on the page (see: [No Content](https://github.com/js-org/js.org/wiki/No-Content))
- [x] I have read and accepted the [Terms and Conditions](http://js.org/terms.html)
