### PR TITLE
flaremc.js.org

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -1083,6 +1083,7 @@ var cnames_active = {
   "extraction": "rse.github.io/extraction", // noCF? (don´t add this in a new PR)
   "eye": "arguiot.github.io/EyeJS",
   "f1": "marinofranz.github.io/f1.ts",
+  "flaremc": "cname.vercel-dns.com",
   "faceapp": "negarang.github.io/face-app",
   "facepalm": "santiagogil.github.io/facepalm",
   "facreative": "facreative.github.io",


### PR DESCRIPTION
Fare is a Minecraft Fabric modpack which customizes the Minecraft's interface and just make it looks awesome! 😎

The website is in development but almost ready, will be developing the site more but currently in need for a domain or subdomain that's why I see js.org as a good option.

The project's website is built using nextjs.
The project's many API's are built using Javascript and Typescript.

Here's the website: https://flaremc.vercel.app/

- [x] There is reasonable content on the page (see: [No Content](https://github.com/js-org/js.org/wiki/No-Content))
- [x] I have read and accepted the [Terms and Conditions](http://js.org/terms.html)