### PR TITLE
Require link + explanation in PR template

### DIFF
--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -1,2 +1,17 @@
-- [x] There is reasonable content on the page (see: [No Content](https://github.com/js-org/js.org/wiki/No-Content))
-- [x] I have read and accepted the [Terms and Conditions](http://js.org/terms.html)
+<!--
+
+Thanks for creating a pull request to request a new subdomain from JS.ORG
+
+Before creating your pull request, please complete the following steps:
+
+- Ensure that your pull request changes only the cnames_active.js file, adding a single new line for your subdomain request
+- Tick the two checkboxes, agreeing to the sentences, below by placing an x inside the square brackets ([ ] becomes [x])
+- Add a link (GitHub repository, Vercel deployment, etc.) and explanation below for your content so we can validate your request
+
+-->
+
+- [ ] There is reasonable content on the page (see: [No Content](https://github.com/js-org/js.org/wiki/No-Content))
+- [ ] I have read and accepted the [Terms and Conditions](http://js.org/terms.html)
+- The site content can be seen at <link>
+
+> The site content is ...

--- a/PULL_REQUEST_TEMPLATE/addExternalPage.md
+++ b/PULL_REQUEST_TEMPLATE/addExternalPage.md
@@ -1,2 +1,0 @@
-- [x] I have read and accepted the [Terms and Conditions](http://js.org/terms.html)
-- [x] There is reasonable content on the page: ***[insert URL here]***

--- a/PULL_REQUEST_TEMPLATE/addGitHubPage.md
+++ b/PULL_REQUEST_TEMPLATE/addGitHubPage.md
@@ -1,3 +1,0 @@
-- [x] I have read and accepted the [Terms and Conditions](http://js.org/terms.html)
-- [x] There is reasonable content on the page
-- [x] I have added a CNAME file to my repo: ***[insert URL here]***


### PR DESCRIPTION
Updates the PR template to have a more verbose set of instructions to make reviewing the PRs a bit easier for us, and explicitly ask for a link to the content plus an explanation of it up front.

Also, removes the PR template directory that GitHub doesn't use.