### PR TITLE
astro-pure.js.org

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -244,6 +244,7 @@ var cnames_active = {
   "ast": "kindy.github.io/ast",
   "astral": "espinielli.github.io/astraljs", // noCF? (don´t add this in a new PR)
   "astro": "withastro.github.io",
+  "astro-pure": "astro-theme-pure.vercel.app",
   "astro-reactive": "astro-reactive.netlify.app",
   "astrobench": "kupriyanenko.github.io/astrobench", // noCF? (don´t add this in a new PR)
   "astx-redux-util": "kevinast.github.io/astx-redux-util",

--- a/cnames_active.js
+++ b/cnames_active.js
@@ -244,7 +244,7 @@ var cnames_active = {
   "ast": "kindy.github.io/ast",
   "astral": "espinielli.github.io/astraljs", // noCF? (don´t add this in a new PR)
   "astro": "withastro.github.io",
-  "astro-pure": "astro-theme-pure.vercel.app",
+  "astro-pure": "cname.vercel-dns.com", // noCF
   "astro-reactive": "astro-reactive.netlify.app",
   "astrobench": "kupriyanenko.github.io/astrobench", // noCF? (don´t add this in a new PR)
   "astx-redux-util": "kevinast.github.io/astx-redux-util",


### PR DESCRIPTION
<!--

Thanks for creating a pull request to request a new subdomain from JS.ORG

Before creating your pull request, please complete the following steps:

- Ensure that your pull request changes only the cnames_active.js file, adding a single new line for your subdomain request
- Tick the two checkboxes, agreeing to the sentences, below by placing an x inside the square brackets ([ ] becomes [x])
- Add a link (GitHub repository, Vercel deployment, etc.) and explanation below for your content so we can validate your request

-->

- [x] There is reasonable content on the page (see: [No Content](https://github.com/js-org/js.org/wiki/No-Content))
- [x] I have read and accepted the [Terms and Conditions](http://js.org/terms.html)
- The site content can be seen at <link>

> The site content is:
> 
> - A astro theme template showing for theme [astro-theme-pure](https://github.com/cworld1/astro-theme-pure)
> - With a [bundled docs](https://astro-theme-pure.vercel.app/docs/list) for theme usage and detailed project development descriptions

Note:

- I cannot split out the template and docs, because I had to show usage and render them on docs page...
- Also I found out that `pure.js.org` is a seven year old and poorly maintained library, is it possible to request this more concise subdomain? I think I might be able to ask the author for unification as much as possible, but before I do so, I need to make sure I actually follow the `js-org` rules and can use the domain name.
