### PR TITLE
Move yak.js.org from Github pages to Vercel

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -3638,7 +3638,7 @@ var cnames_active = {
   "y86": "quietshu.github.io/y86", // noCF? (don´t add this in a new PR)
   "yadl": "yadljs.github.io",
   "yagolopez": "yagolopez.github.io",
-  "yak": "jantimon.github.io/next-yak",
+  "yak": "name.vercel-dns.com", // noCF
   "yake": "yakeing.github.io/HexoBlog",
   "yamdbf": "zajrik.github.io/yamdbf",
   "yan": "yvesyc.github.io/yan-js-org",


### PR DESCRIPTION
- [x] There is reasonable content on the page
- [x] I have read and accepted the [Terms and Conditions](http://js.org/terms.html)
- The site content can be seen at https://next-yak-docs.vercel.app/
