### PR TITLE
Remove invidjs.js.org

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -1515,7 +1515,6 @@ var cnames_active = {
   "internetmarke": "schaechinger.github.io/internetmarke",
   "interview": "fengzilong.github.io/interview-101",
   "invent": "isaiahpatton.github.io/InventJS",
-  "invidjs": "invidjs.github.io/docs",
   "invoicing": "vahe.github.io/InvoicingJs",
   "iot": "product-engineer.github.io/iot.js.org", // noCF
   "ip-address": "beaugunderson.github.io/ip-address", // noCF? (don´t add this in a new PR)


### PR DESCRIPTION
Removing this subdomain because the project is no longer maintained.
