### PR TITLE
bukumark.js.org

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -436,7 +436,6 @@ var cnames_active = {
   "bud": "roots-bud.netlify.app",
   "bui": "kjantzer.github.io/bui",
   "builders": "cname.vercel-dns.com", // noCF
-  "bukumark": "ligmatv.github.io/Bukumark",
   "bullwinkle": "bullwinkle.github.io",
   "bun": "the94air.github.io/bun",
   "bundle": "cname.vercel-dns.com", // noCF


### PR DESCRIPTION
Delete https://bukumark.js.org
This project is dead and archived, and no one is using it either.