### PR TITLE
Add katidoki.is-a.dev

### DIFF
--- a/cnames/katidoki.is-a.dev.json
+++ b/cnames/katidoki.is-a.dev.json
@@ -1,0 +1,7 @@
+{
+  "owner": "hitoshi-okada",
+  "repo": "katidoki.github.io",
+  "branch": "main",
+  "path": "/",
+  "custom_domain": "katidoki.is-a.dev"
+}


### PR DESCRIPTION
### Domain Request

**Subdomain:** `katidoki`  
**Domain:** `is-a.dev`

### Purpose
Hosting a Teams bot that integrates product and customer data search for internal productivity.

### Website Preview (GitHub Pages)
https://hitoshi-okada.github.io/katidoki.github.io/

### Additional Info
This bot is built using Microsoft Bot Framework, Python, and Cloudflared tunnel. Hosted via GitHub Pages.

- [x] There is reasonable content on the page (see: [No Content](https://github.com/js-org/js.org/wiki/No-Content))
- [x] I have read and accepted the [Terms and Conditions](http://js.org/terms.html)