### PR TITLE
niu.js.org

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -2230,6 +2230,7 @@ var cnames_active = {
   "niplayer": "niyuancheng.github.io/NiPlayerDocs",
   "nite": "manvalls.github.io/nite",
   "nitrate": "ranjithrd.github.io/nitrate",
+  "niu": "h105.hubuhost.com",
   "nnmap": "marzavec.github.io/nnmap.js",
   "no-pry": "zenyanle.github.io/node-unblocker",
   "nobelium": "cname.vercel-dns.com", // noCF


### PR DESCRIPTION
I want to register a niu.js.org to replace niu.icu. niu.icu is a mature blog system that I deployed on my own server.