### PR TITLE
comptime.js.org

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -622,6 +622,7 @@ var cnames_active = {
   "common-utils-pkg": "iamdevlinph.github.io/common-utils-pkg",
   "composedb": "ceramicstudio.github.io/js-composedb",
   "compoundinterest": "nategiraudeau.github.io/compound-interest-calculator",
+  "comptime": "feathers-studio.github.io/comptime.ts",
   "computed": "krmax44.github.io/rollup-plugin-computed",
   "concurrent-tasks": "samrith-s.github.io/concurrent-tasks",
   "concursos": "mteyss.github.io/concursos", // noCF? (don´t add this in a new PR)


### PR DESCRIPTION
- [x] There is reasonable content on the page (see: [No Content](https://github.com/js-org/js.org/wiki/No-Content))
- [x] I have read and accepted the [Terms and Conditions](http://js.org/terms.html)
- The site content can be seen at https://feathers-studio.github.io/comptime.ts

> The site is documentation for `comptime.ts`, a project that allows comptime evaluation and removal of expressions. It's also available as a Vite plugin, other than standalone and CLI. Source available at https://github.com/feathers-studio/comptime.ts and published to npm as http://npmjs.com/package/comptime.ts.