### PR TITLE
add mdjs.js.org

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -1975,6 +1975,7 @@ var cnames_active = {
   "mdbf-css": "more-beautiful-div-framework.github.io",
   "mdcdev": "galleniz.github.io/mdcdev.js",
   "mde": "lukehorvat.github.io/mde-soundboard",
+  "mdjs": "xtnmoe.github.io/MdJs",
   "mdxe": "cname.vercel-dns.com", // noCF
   "mechan": "dusterthefirst.github.io/mechan.js",
   "medan": "medan-js.github.io", // noCF


### PR DESCRIPTION

- [x] There is reasonable content on the page (see: [No Content](https://github.com/js-org/js.org/wiki/No-Content))
- [x] I have read and accepted the [Terms and Conditions](http://js.org/terms.html)
- The site content can be seen at [https://xtnmoe.github.io/MdJs/](https://xtnmoe.github.io/MdJs/)
or [https://github.com/xtnmoe/MdJs/blob/main/README-en-US.md](https://github.com/xtnmoe/MdJs/blob/main/README-en-US.md)

> The site content is a purely static document rendering tool

- I've added it on line 1978 of the cnames_active.js
"mdjs": "xtnmoe.github.io/MdJs",