### PR TITLE
jsonapi-serde.js.org

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -1648,6 +1648,7 @@ var cnames_active = {
   "json-schema-faker": "json-schema-faker.github.io/website-jsf",
   "json-to-plain-text": "sumithemmadi.github.io/json-to-plain-text",
   "jsonapi": "ethanresnick.github.io/json-api",
+  "jsonapi-serde": "dasprid.github.io/jsonapi-serde-js",
   "jsoning": "khalby786.github.io/jsoning",
   "jsonql": "joel-chu.github.io/jsonql-org",
   "jsonui": "yourtion.github.io/vue-json-ui-editor",


### PR DESCRIPTION
<!--

Thanks for creating a pull request to request a new subdomain from JS.ORG

Before creating your pull request, please complete the following steps:

- Ensure that your pull request changes only the cnames_active.js file, adding a single new line for your subdomain request
- Tick the two checkboxes, agreeing to the sentences, below by placing an x inside the square brackets ([ ] becomes [x])
- Add a link (GitHub repository, Vercel deployment, etc.) and explanation below for your content so we can validate your request

-->

- [x] There is reasonable content on the page (see: [No Content](https://github.com/js-org/js.org/wiki/No-Content))
- [x] I have read and accepted the [Terms and Conditions](http://js.org/terms.html)
- The site content can be seen at https://dasprid.github.io/jsonapi-serde-js/ (partially broken because vitepress expects the site to live at root).

> The site content is Vitepress documentation for jsonapi-serde.

Not too sure if the subdomain name is okay though. In general it conflicts with your naming rules:

> Must either be the username or the sub path.

I have suffixed the repository name with `-js`, as I plan to have a similar project to be written in Rust, which would then get `-rs` suffix in my repository list. So the suffix is just for avoiding naming collisions, and I'd prefer to not have `js` twice in the url: `json-serde-js.js.org`, if possible :)

