### PR TITLE
react-facet.js.org

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -2648,7 +2648,6 @@ var cnames_active = {
   "react-dropzone-uploader": "fortana-co.github.io/react-dropzone-uploader",
   "react-easy-swipe": "leandrowd.github.io/react-easy-swipe", // noCF? (don´t add this in a new PR)
   "react-entanglement": "react-entanglement.github.io",
-  "react-facet": "jolly-stone-0d2f00e03.azurestaticapps.net", // noCF
   "react-hint": "slmgc.github.io/react-hint",
   "react-instastories": "kenclaron.github.io/react-instastories",
   "react-jewish-datepicker": "shmulik-kravitz.github.io/react-jewish-datepicker",


### PR DESCRIPTION
- [x] There is reasonable content on the page (see: [No Content](https://github.com/js-org/js.org/wiki/No-Content))
- [x] I have read and accepted the [Terms and Conditions](http://js.org/terms.html)
- The site content can be seen at https://react-facet.mojang.com/

> The site content is moving to a new custom domain.

Hi!

We've started using our own custom domain to host our documentation website. So the js.org domain is no longer needed.

I'm also the author of the original PR that added this domain at #6505.

We highly appreciate the service provided during these past years.

Cheers,

cc @Bahamoe