### PR TITLE
markdown-html.js.org

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -1949,6 +1949,7 @@ var cnames_active = {
   "marionette": "marionettejs.github.io/marionettejs.com",
   "mark": "henry-luo.github.io/mark",
   "markbox": "markbox.netlify.app",
+  "markdown-html": "PJ-568.github.io/MARKDOWN.HTML",
   "markdown-notepad": "jz222.github.io/markdown-notepad",
   "markdownify": "amitmerchant1990.github.io/electron-markdownify",
   "marked": "cname.vercel-dns.com", // noCF

--- a/cnames_active.js
+++ b/cnames_active.js
@@ -1949,7 +1949,7 @@ var cnames_active = {
   "marionette": "marionettejs.github.io/marionettejs.com",
   "mark": "henry-luo.github.io/mark",
   "markbox": "markbox.netlify.app",
-  "markdown-html": "PJ-568.github.io/MARKDOWN.HTML",
+  "markdown-html": "pj-568.github.io/MARKDOWN.HTML",
   "markdown-notepad": "jz222.github.io/markdown-notepad",
   "markdownify": "amitmerchant1990.github.io/electron-markdownify",
   "marked": "cname.vercel-dns.com", // noCF


### PR DESCRIPTION
- [x] There is reasonable content on the page (see: [No Content](https://github.com/js-org/js.org/wiki/No-Content))
- [x] I have read and accepted the [Terms and Conditions](http://js.org/terms.html)
- The site content can be seen at https://github.com/PJ-568/MARKDOWN.HTML/blob/main/index.html

> The site content is [markdown.html](https://github.com/PJ-568/MARKDOWN.HTML/blob/main/README_EN.md), which aims to provide a low-dependency, simple deployment solution for rendering Markdown web pages.
>
> This site display [markdown.html](https://github.com/PJ-568/MARKDOWN.HTML/blob/main/README_EN.md)'s readme files and documents using [markdown.html](https://github.com/PJ-568/MARKDOWN.HTML/blob/main/index.html) itself.
