### PR TITLE
add lift-html

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -1717,6 +1717,7 @@ var cnames_active = {
   "libphonenumbers": "libphonenumbers.github.io",
   "license-cop": "tobysmith568.github.io/license-cop",
   "lifeisyoung": "lifeisyoung.github.io",
+  "lift-html": "jlarky.github.io/lift-html",
   "light": "lightjs.netlify.app",
   "light-observable": "dmitry-korolev.github.io/light-observable",
   "lightcord": "snazzah.github.io/Lightcord",


### PR DESCRIPTION
- [x] There is reasonable content on the page (see: [No Content](https://github.com/js-org/js.org/wiki/No-Content))
- [x] I have read and accepted the [Terms and Conditions](http://js.org/terms.html)
- The site content can be seen at https://jlarky.github.io/lift-html/ (I had to remove cuctom domain from GH Pages settings otherwise it was redirecting)

This is a docs website for a npm package that I'm building called liFt-html https://github.com/JLarky/lift-html/tree/main

The site is deployed with GH pages via CI https://github.com/JLarky/lift-html/actions/runs/16348542687