### PR TITLE
msemoji.js.org

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -2024,7 +2024,7 @@ var cnames_active = {
   "mrpluto": "mrpluto.github.io",
   "mrwanashraf": "mrwanashraf.github.io",
   "mscgen": "sverweij.github.io/mscgen_js",
-  "msemoji": "dellzhackintosh.github.io/msemoji",
+  "msemoji": "zdalez.github.io/msemoji",
   "msolers": "msolers.github.io/bloghugo",
   "msp430": "mazko.github.io/MSP430.js",
   "mtproto-core": "alik0211.github.io/mtproto-core-website",


### PR DESCRIPTION
- [x] There is reasonable content on the page (see: [No Content](https://github.com/js-org/js.org/wiki/No-Content))
- [x] I have read and accepted the [Terms and Conditions](http://js.org/terms.html)
- The site content can be seen at https://msemoji.js.org/index-en.html

> The site content is the same project before, but needs update domain (https://github.com/js-org/js.org/pull/8423).

Due to username change, the origin domain that associated with msemoji.js.org has not been `dellzhackintosh.github.io/msemoji` now, but `zdalez.github.io/msemoji` instead.

`msemoji.js.org` continues working at this time, but cannot be guaranteed that it will continue to work normally in the future. That's the purpose of this PR.

Additionally, we added a DNS TXT record to verify the domain before. If necessarry, it could be done again:

> 1. Create a TXT record in your DNS configuration for the following hostname: _github-pages-challenge-zDaleZ.msemoji.js.org
> 2. Use this code for the value of the TXT record: 8ca626f101f17ad48a6eabe0370278
> 3. Wait until your DNS configuration changes. This could take up to 24 hours to propagate.

Thanks for your hard work!