### PR TITLE
add cuberush.js.org

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -3576,7 +3576,8 @@ var cnames_active = {
   "zyh": "zyh-chopper.github.io/zyh",
   "zykj": "cname.vercel-dns.com", // noCF
   "zyx": "zyx.alwaysdata.net",
-  "zyy": "zyyou.github.io/notes"
+  "zyy": "zyyou.github.io/notes",
+  "cuberush": "cuberush.vercel.app"
   /*
    * please don't add your subdomain records down here!
    * insert them in alphabetical order to help reduce merge conflicts.


### PR DESCRIPTION
I want to use cuberush.js.org for my JavaScript-based cube timer app hosted on Vercel: https://cuberush.vercel.app/
