### PR TITLE
codetwix.js.org

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -567,6 +567,7 @@ var cnames_active = {
   "codemade": "codemade.github.io", // noCF? (don´t add this in a new PR)
   "codemirror-languageservice": "codemirror-languageservice.netlify.app",
   "codeshare": "cname.vercel-dns.com", // noCF
+  "codetwix": "nolan639.github.io/Codetwix",
   "codewing": "nicesapien.github.io/codewing",
   "codinsky": "izhaki.github.io/codinsky",
   "coffea": "caffeinery.github.io/coffea",


### PR DESCRIPTION
Requesting codetwix.js.org subdomain for my GitHub Pages site.
Repository: https://github.com/Nolan639/Codetwix
- [x] There is reasonable content on the page (see: [No Content](https://github.com/js-org/js.org/wiki/No-Content))
- [x] I have read and accepted the [Terms and Conditions](http://js.org/terms.html)