### PR TITLE
minecraftcalculator.js.org

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -3584,6 +3584,7 @@ var cnames_active = {
   "zykj": "cname.vercel-dns.com", // noCF
   "zyx": "zyx.alwaysdata.net",
   "zyy": "zyyou.github.io/notes"
+  "minecraftcalculator": "notlycoding045.github.io/Minecraft-logo-and-photos-",
   /*
    * please don't add your subdomain records down here!
    * insert them in alphabetical order to help reduce merge conflicts.


### PR DESCRIPTION
I would like to request the subdomain: minecraftcalculator.js.org pointing to [https://notlycoding045.github.io/MinecraftCalculato].