### PR TITLE
add msx31.js.org

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -2030,6 +2030,8 @@ var cnames_active = {
   "msemoji": "zdalez.github.io/msemoji",
   "msolers": "msolers.github.io/bloghugo",
   "msp430": "mazko.github.io/MSP430.js",
+  "msx31": "maheshsthr.github.io/msx31",
+
   "mtproto-core": "alik0211.github.io/mtproto-core-website",
   "mubaidr": "mubaidr.github.io",
   "muc": "jsmuc.github.io",


### PR DESCRIPTION
Requesting subdomain msx31.js.org for my GitHub Pages site (maheshsthr.github.io/msx31)

- [x] There is reasonable content on the page (see: [No Content](https://github.com/js-org/js.org/wiki/No-Content))
- [x] I have read and accepted the [Terms and Conditions](http://js.org/terms.html)

- The site content can be seen at: https://maheshsthr.github.io/msx31

> The site is a personal portfolio made using HTML and CSS, hosted on GitHub Pages.
