### PR TITLE
auto-comment on PR template CI failure (#9789)

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -48,39 +48,60 @@ jobs:
         working-directory: cleanup
 
   validate-pr-template:
-    if: github.event_name == 'pull_request'
+  if: github.event_name == 'pull_request'
+  runs-on: ubuntu-latest
 
-    runs-on: ubuntu-latest
+  steps:
+    - name: Validate PR template and comment
+      uses: actions/github-script@v7
+      with:
+        script: |
+          const pr = context.payload.pull_request;
+          const body = pr.body || "";
 
-    steps:
-      - name: Validate PR template
-        uses: actions/github-script@v7
-        with:
-          script: |
-            const body = context.payload.pull_request.body || "";
+          const checkbox1 = /\[x\].*?There is reasonable content/i.test(body);
+          const checkbox2 = /\[x\].*?I have read and accepted/i.test(body);
+          const urlLineRegex = /^[ \t]*-[ \t]*The site content can be seen at[ \t]+(?:<)?(?:\[.*?\]\()?https?:\/\/[^\s>()]+(?:\))?(?:>)?/m;
+          const urlValid = urlLineRegex.exec(body) !== null;
+          const explanationMatch = />\s*The site content is(?:\s*|\s*\n)(.+)/i.exec(body);
+          const explanation = explanationMatch && explanationMatch[1].trim().length > 10;
 
-            // 1. Check both checkboxes
-            const checkbox1 = /\[x\].*?There is reasonable content/i.test(body);
-            const checkbox2 = /\[x\].*?I have read and accepted/i.test(body);
+          const failed = !checkbox1 || !checkbox2 || !urlValid || !explanation;
 
-            // 2. URL must be on the exact "The site content can be seen at ..." line
-            // https://regex101.com/r/N36fsT
-            const urlLineRegex = /^[ \t]*-[ \t]*The site content can be seen at[ \t]+(?:<)?(?:\[.*?\]\()?https?:\/\/[^\s>()]+(?:\))?(?:>)?/m;
-            const urlMatch = urlLineRegex.exec(body);
-            const urlValid = urlMatch !== null;
+          if (!failed) {
+            console.log("✅ PR template is valid.");
+            return;
+          }
 
-            // 3. Explanation must follow the blockquote marker
-            const explanationMatch = />\s*The site content is(?:\s*|\s*\n)(.+)/i.exec(body);
-            const explanation = explanationMatch && explanationMatch[1].trim().length > 10;
+          const commentBody = `❌ **PR template is not properly filled:**\n\n- Checkbox1 (reasonable content): ${checkbox1 ? "✅" : "❌"}\n- Checkbox2 (read and accepted): ${checkbox2 ? "✅" : "❌"}\n- URL on correct line: ${urlValid ? "✅" : "❌"}\n- Explanation (> The site content is...): ${explanation ? "✅" : "❌"}\n\nPlease update your PR description accordingly.`;
 
-            if (!checkbox1 || !checkbox2 || !urlValid || !explanation) {
-              core.setFailed(
-                "❌ PR template is not properly filled:\n" +
-                `Checkbox1: ${checkbox1 ? '✅' : '❌'}\n` +
-                `Checkbox2: ${checkbox2 ? '✅' : '❌'}\n` +
-                `URL on correct line: ${urlValid ? '✅' : '❌'}\n` +
-                `Explanation: ${explanation ? '✅' : '❌'}`
-              );
-            } else {
-              console.log("✅ PR template format is valid.");
-            }
+          const { data: comments } = await github.rest.issues.listComments({
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            issue_number: pr.number,
+          });
+
+          const existingComment = comments.find(c =>
+            c.user.login === 'github-actions[bot]' &&
+            c.body.includes("**PR template is not properly filled:**")
+          );
+
+          if (existingComment) {
+            await github.rest.issues.updateComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              comment_id: existingComment.id,
+              body: commentBody
+            });
+            console.log("🔁 Updated existing PR comment.");
+          } else {
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: pr.number,
+              body: commentBody
+            });
+            console.log("💬 Posted new PR comment.");
+          }
+
+          core.setFailed("PR template validation failed.");

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -48,60 +48,58 @@ jobs:
         working-directory: cleanup
 
   validate-pr-template:
-  if: github.event_name == 'pull_request'
-  runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
 
-  steps:
-    - name: Validate PR template and comment
-      uses: actions/github-script@v7
-      with:
-        script: |
-          const pr = context.payload.pull_request;
-          const body = pr.body || "";
+    steps:
+      - name: Validate PR template and comment
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const pr = context.payload.pull_request;
+            const body = pr.body || "";
 
-          const checkbox1 = /\[x\].*?There is reasonable content/i.test(body);
-          const checkbox2 = /\[x\].*?I have read and accepted/i.test(body);
-          const urlLineRegex = /^[ \t]*-[ \t]*The site content can be seen at[ \t]+(?:<)?(?:\[.*?\]\()?https?:\/\/[^\s>()]+(?:\))?(?:>)?/m;
-          const urlValid = urlLineRegex.exec(body) !== null;
-          const explanationMatch = />\s*The site content is(?:\s*|\s*\n)(.+)/i.exec(body);
-          const explanation = explanationMatch && explanationMatch[1].trim().length > 10;
+            const checkbox1 = /\[x\].*?There is reasonable content/i.test(body);
+            const checkbox2 = /\[x\].*?I have read and accepted/i.test(body);
+            const urlLineRegex = /^[ \t]*-[ \t]*The site content can be seen at[ \t]+(?:<)?(?:\[.*?\]\()?https?:\/\/[^\s>()]+(?:\))?(?:>)?/m;
+            const urlValid = urlLineRegex.exec(body) !== null;
+            const explanationMatch = />\s*The site content is(?:\s*|\s*\n)(.+)/i.exec(body);
+            const explanation = explanationMatch && explanationMatch[1].trim().length > 10;
 
-          const failed = !checkbox1 || !checkbox2 || !urlValid || !explanation;
+            const failed = !checkbox1 || !checkbox2 || !urlValid || !explanation;
 
-          if (!failed) {
-            console.log("✅ PR template is valid.");
-            return;
-          }
+            if (!failed) {
+              console.log("✅ PR template is valid.");
+              return;
+            }
 
-          const commentBody = `❌ **PR template is not properly filled:**\n\n- Checkbox1 (reasonable content): ${checkbox1 ? "✅" : "❌"}\n- Checkbox2 (read and accepted): ${checkbox2 ? "✅" : "❌"}\n- URL on correct line: ${urlValid ? "✅" : "❌"}\n- Explanation (> The site content is...): ${explanation ? "✅" : "❌"}\n\nPlease update your PR description accordingly.`;
+            const commentBody = `❌ **PR template is not properly filled:**\n\n- Checkbox1 (reasonable content): ${checkbox1 ? "✅" : "❌"}\n- Checkbox2 (read and accepted): ${checkbox2 ? "✅" : "❌"}\n- URL on correct line: ${urlValid ? "✅" : "❌"}\n- Explanation (> The site content is...): ${explanation ? "✅" : "❌"}\n\nPlease update your PR description accordingly.`;
 
-          const { data: comments } = await github.rest.issues.listComments({
-            owner: context.repo.owner,
-            repo: context.repo.repo,
-            issue_number: pr.number,
-          });
-
-          const existingComment = comments.find(c =>
-            c.user.login === 'github-actions[bot]' &&
-            c.body.includes("**PR template is not properly filled:**")
-          );
-
-          if (existingComment) {
-            await github.rest.issues.updateComment({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              comment_id: existingComment.id,
-              body: commentBody
-            });
-            console.log("🔁 Updated existing PR comment.");
-          } else {
-            await github.rest.issues.createComment({
+            const { data: comments } = await github.rest.issues.listComments({
               owner: context.repo.owner,
               repo: context.repo.repo,
               issue_number: pr.number,
-              body: commentBody
             });
-            console.log("💬 Posted new PR comment.");
-          }
 
-          core.setFailed("PR template validation failed.");
+            const existingComment = comments.find(c =>
+              c.user.login === 'github-actions[bot]' &&
+              c.body.includes("**PR template is not properly filled:**")
+            );
+
+            if (existingComment) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existingComment.id,
+                body: commentBody
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: pr.number,
+                body: commentBody
+              });
+            }
+
+            core.setFailed("PR template validation failed.");


### PR DESCRIPTION
<!--

Thanks for creating a pull request to request a new subdomain from JS.ORG

Before creating your pull request, please complete the following steps:

- Ensure that your pull request changes only the cnames_active.js file, adding a single new line for your subdomain request
- Tick the two checkboxes, agreeing to the sentences, below by placing an x inside the square brackets ([ ] becomes [x])
- Add a link (GitHub repository, Vercel deployment, etc.) and explanation below for your content so we can validate your request

-->

- [x] There is reasonable content on the page (see: [No Content](https://github.com/js-org/js.org/wiki/No-Content))  
- [x] I have read and accepted the [Terms and Conditions](http://js.org/terms.html)  

- The site content can be seen at <https://github.com/js-org/js.org/pull/9789>

> 🛠 This PR adds a GitHub Actions workflow that automatically comments on PRs which do not follow the required template (as discussed in issue #9789). This improves maintainability and contributor experience.