### PR TITLE
pixelsmp.js.org

### DIFF
--- a/pixelsmp.js.org.json
+++ b/pixelsmp.js.org.json
@@ -1,0 +1,6 @@
+{
+  "owner": {
+    "github": "ak-pumkin"
+  },
+  "target": "https://ak-pumkin.github.io/pixelsmp-web/#"
+}


### PR DESCRIPTION
Added a new entry for pixelsmp.js.org subdomain.
Targeting https://ak-pumkin.github.io/pixelsmp-web/#