### PR TITLE
ko.mobx.js.org & zh.mobx.js.org

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -1623,6 +1623,7 @@ var cnames_active = {
   "kmeans": "jeff-tian.github.io/k-means",
   "knc": "chaituknag.github.io",
   "ko": "ko25july.github.io/ko.js.org",
+  "ko.mobx": "cname.vercel-dns.com", // noCF
   "ko.redux": "deminoth.github.io/redux", // noCF
   "koa-rest-api-boilerplate": "posquit0.github.io/koa-rest-api-boilerplate",
   "kobra": "johnsylvain.github.io/kobra",
@@ -3572,6 +3573,7 @@ var cnames_active = {
   "zeroframe": "filips123.github.io/ZeroFrameJS",
   "zh-cn-ydk": "ydkjsy-zh.netlify.app",
   "zh-hans.single-spa": "single-spa.github.io/zh-hans.single-spa.js.org", // noCF
+  "zh.mobx": "cname.vercel-dns.com", // noCF
   "zhangnew": "zhangnew.github.io",
   "zhaomenghuan": "zhaomenghuan.github.io",
   "zhd": "zhdmitry.github.io",


### PR DESCRIPTION
<!--

Thanks for creating a pull request to request a new subdomain from JS.ORG

Before creating your pull request, please complete the following steps:

- Ensure that your pull request changes only the cnames_active.js file, adding a single new line for your subdomain request
- Tick the two checkboxes, agreeing to the sentences, below by placing an x inside the square brackets ([ ] becomes [x])
- Add a link (GitHub repository, Vercel deployment, etc.) and explanation below for your content so we can validate your request

-->

- [x] There is reasonable content on the page (see: [No Content](https://github.com/js-org/js.org/wiki/No-Content))
- [x] I have read and accepted the [Terms and Conditions](http://js.org/terms.html)
- The site content can be seen at [zh-mobx-js-org.vercel.app](https://zh-mobx-js-org.vercel.app/README.html) & [ko-mobx-js-org.vercel.app](https://ko-mobx-js-org.vercel.app/README.html)

> Mobxjs korean & chinese documentation webiste. 
https://github.com/js-org/js.org/pull/9945  This PR removed the ko.mobx.js.org and zh.mobx.js.org domains.
After a month of negotiations, Vercel has resumed its sponsorship of our documentation website, which is now accessible as usual.
