### PR TITLE
stax.js.org

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -2991,6 +2991,7 @@ var cnames_active = {
   "statsmonit": "cabrata.github.io/StatsMonit",
   "status": "mattipv4.github.io/status-codes",
   "status-hx": "status-hx-js-org.dns.huangxin.org", // noCF
+  "stax": "stax.serv00.net",
   "steemsites": "yhozen.github.io/steemsites",
   "stego": "zeruniverse.github.io/CryptoStego", // noCF? (don´t add this in a new PR)
   "stein": "cname.vercel-dns.com", // noCF


### PR DESCRIPTION
- [x] There is reasonable content on the page (see: [No Content](https://github.com/js-org/js.org/wiki/No-Content))
- [x] I have read and accepted the [Terms and Conditions](http://js.org/terms.html)
- The site content can be seen at [stax.serv00.net](https://stax.serv00.net)

> The site content is javascript documentation for stax.js. PR #9945 removed the domain, there were problems with the hosting provider that caused issues with the website. We have resolved  these issues. 