### PR TITLE
Add hicatgamer.js.org for my GitHub Pages site

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -1358,6 +1358,7 @@ var cnames_active = {
   "heroku": "gary50613.github.io/herokuapi.js",
   "hexoplusplus": "hexoplusplus.github.io/docs",
   "hibiki": "claritymoe.github.io/hibiki",
+  "hicatgamer": "samuelthorn.github.io/bingohicat/",
   "hiddenfrombots": "cname.vercel-dns.com", // noCF
   "highfive": "hosting.gitbook.io", // noCF
   "highway": "dogstudio.github.io/highway",


### PR DESCRIPTION
Please add hicatgamer.js.org pointing to meuusuario.github.io. The site is hosted on GitHub Pages and is public.
