### PR TITLE
Remove chatgpt.js.org – trademark violation (§4 TOS)

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -506,7 +506,6 @@ var cnames_active = {
   "charge": "charge-js.netlify.app",
   "chariot": "riyacchi.github.io/chariot.js",
   "chatexchange": "jacob-gray.github.io/ChatExchangeJS",
-  "chatgpt": "chatgptjs.github.io/chatgpt.js",
   "checkers": "davidpomerenke.github.io/checkers",
   "cheerio": "cheeriojs.github.io/cheerio",
   "chenkun": "ck123-rgb.github.io/chenkun-js-org",


### PR DESCRIPTION
@adamlui #8163

We want to inform you that the subdomain chatgpt.js.org has been removed.

This action was necessary because we received a trademark infringement complaint from OpenAI’s brand enforcement partner. After review, we found that the use of the term “ChatGPT” in the subdomain violates §4 of the JS.ORG Terms of Service (copyright and trademark offenses are prohibited: https://js.org/terms.html#$4).

We understand this may be disappointing, but we must comply with valid IP claims to protect the JS.ORG service and its community.

If you’d like, you are welcome to request a new subdomain under a different name that does not include protected trademarks (for example, something more descriptive of your project, like gpt-wrapper.js.org or another neutral identifier).

Thank you for your understanding.

<!--

Thanks for creating a pull request to request a new subdomain from JS.ORG

Before creating your pull request, please complete the following steps:

- Ensure that your pull request changes only the cnames_active.js file, adding a single new line for your subdomain request
- Tick the two checkboxes, agreeing to the sentences, below by placing an x inside the square brackets ([ ] becomes [x])
- Add a link (GitHub repository, Vercel deployment, etc.) and explanation below for your content so we can validate your request

-->

- [ ] There is reasonable content on the page (see: [No Content](https://github.com/js-org/js.org/wiki/No-Content))
- [ ] I have read and accepted the [Terms and Conditions](http://js.org/terms.html)
- The site content can be seen at <link>

> The site content is ...
