### PR TITLE
myproject.js.org

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -2063,6 +2063,7 @@ var cnames_active = {
   "mwap": "jacob-ebey.github.io/mwap",
   "mx-space": "mx-space.github.io/docs", // noCF
   "my-app": "osidecrotchets.github.io/my-app",
+  "myproject": "mosroom.github.io/meme-break-extension",
   "my-server": "nirrius.github.io/my-server",
   "mylas": "raouldeheer.github.io/Mylas",
   "mysketch": "dipanshkhandelwal.github.io/MySketch",


### PR DESCRIPTION
I would like to request meme-break-extension.js.org for the landing page of my Chrome extension.  
The site is hosted on GitHub Pages at https://mosroom.github.io/meme-break-extension 
It contains information about the extension and a link to the Chrome Web Store.  
