### PR TITLE
Request for mrprince.js.org subdomain 

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -2073,6 +2073,7 @@ var cnames_active = {
   "mythbusters": "cname.vercel-dns.com", // noCF
   "myurl": "marvnet.github.io/myurl",
   "mzaini30": "mzaini30.github.io",
+  "mrprincearya": "mrprince-arya.github.io/MrNice-Arya-Material-Design"
   "mzplayer": "prince3661.github.io/Mzplayer",
   "n": "cyb.github.io/n",
   "nabin": "nabin6246.github.io",


### PR DESCRIPTION
I would like to request the subdomain **mrprince.js.org** for my GitHub Pages site hosted at **https://mrprince.github.io/MrPrince-Arya-Material-Design**.

The site contains multiple features including a dashboard, forms, calculator, notes, and quick links. It is not a single page or redirect, and provides useful content for daily productivity.

Thank you!
