### PR TITLE
Add HashKeys - Vue reactive cryptography toolbox

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -1342,6 +1342,7 @@ var cnames_active = {
   "hashchat": "hashchat-js.netlify.app",
   "hashfs": "defucc.github.io/hashfs",
   "hashjump": "fivefifteen.github.io/hashjump",
+  "hashkeys": "defucc.github.io/hashkeys",
   "hasura-om": "mrspartak.github.io/hasura-om",
   "hay": "hayjs.github.io/hay.js.org",
   "hbase": "adaltas.github.io/node-hbase-docs",


### PR DESCRIPTION
- [x] There is reasonable content on the page (see: [No Content](https://github.com/js-org/js.org/wiki/No-Content))
- [x] I have read and accepted the [Terms and Conditions](http://js.org/terms.html)
- The site content can be seen at https://github.com/DeFUCC/hashkeys/blob/gh-pages/index.html

> The site content is another facet of all three hash* package suite project - hashfs is already published 🙏, now I'm publishing hashkeys and then in a week or so hashavatar should be also ready. That would be it for now.  It's three fulcrums for strong privacy ready to use in next generation p2p web-apps. And it's all MIT 😊