### PR TITLE
m8captcha.js.org

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -1827,6 +1827,7 @@ var cnames_active = {
   "m01i0ng": "m01i0ng.github.io",
   "m3ripple": "yuyake-litrain.github.io/m3ripple-web",
   "m8bot": "mapreiff.github.io/m8-bot-site",
+  "m8captcha": "wowcaptcha.netlify.app",
   "ma124": "ma124.netlify.app",
   "macaron": "macaron-css.github.io/macaron",
   "machinelearning": "marink.github.io/machinelearning",


### PR DESCRIPTION
<!--

Thanks for creating a pull request to request a new subdomain from JS.ORG

Before creating your pull request, please complete the following steps:

- Ensure that your pull request changes only the cnames_active.js file, adding a single new line for your subdomain request
- Tick the two checkboxes, agreeing to the sentences, below by placing an x inside the square brackets ([ ] becomes [x])
- Add a link (GitHub repository, Vercel deployment, etc.) and explanation below for your content so we can validate your request

-->

- [x] There is reasonable content on the page (see: [No Content](https://github.com/js-org/js.org/wiki/No-Content))
- [x] I have read and accepted the [Terms and Conditions](http://js.org/terms.html)
- The site content can be seen at <https://wowcaptcha.netlify.app>

> The site content is the same one in my pull request of "captcha.js.org". i am making a new one because the reason captcha.js.org did not get accepted was, in short, it being too simple and not safe for that subdomain. so i will use m8captcha instead (mateCaptcha being its new name now) since surely people would prefer having the captcha subdomain over m8captcha.js.org. @MattIPv4 
