### PR TITLE
add dailypixel.js.org

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -702,6 +702,7 @@ var cnames_active = {
   "d-patterns": "alias.zeit.co", // noCF
   "d4": "joelburget.github.io/d4",
   "daily.tmr": "tmr-daily.netlify.app", // noCF
+  "dailypixel": "dailypixelsite.github.io/daily-pixel",
   "daisy": "warengonzaga.github.io/daisy.js",
   "daksh0225": "daksh0225.github.io",
   "damo": "damodharanj.github.io",


### PR DESCRIPTION
This PR adds the subdomain dailypixel.js.org pointing to my GitHub Pages site.

Subdomain: dailypixel.js.org
Target: dailypixelsite.github.io/daily-pixel
