### PR TITLE
Update PR template guidance to highlight content requirements

### DIFF
--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -2,11 +2,19 @@
 
 Thanks for creating a pull request to request a new subdomain from JS.ORG
 
-Before creating your pull request, please complete the following steps:
+Before creating your pull request, please read and complete the following steps:
 
 - Ensure that your pull request changes only the cnames_active.js file, adding a single new line for your subdomain request
-- Tick the two checkboxes, agreeing to the sentences, below by placing an x inside the square brackets ([ ] becomes [x])
-- Add a link (GitHub repository, Vercel deployment, etc.) and explanation below for your content so we can validate your request
+  - Follow the existing format established by the other entries, a new line with the subdomain as the key and the target hostname as the value
+  - Add your new line to the file in alphabetical order, and follow the guidance given by the comments in the file itself
+
+- Fill out this pull request template in your pull request description, maintaining the format provided to you
+  - Tick the two checkboxes, agreeing to the sentences, below by placing an x inside the square brackets ([ ] becomes [x])
+  - Add a link (GitHub repository, Vercel deployment, etc.), so we can review your site
+  - Explain what your site content is and how it relates to the JavaScript community/ecosystem, so we can validate your request
+
+- Ensure that your site content follows the content requirements set out in our README: https://github.com/js-org/js.org#content-requirements
+  - Notably, make sure that your site is not a personal site, and that it is clearly content that is relevant to the JavaScript community/ecosystem
 
 -->
 

--- a/README.md
+++ b/README.md
@@ -54,6 +54,8 @@ As above with adding a subdomain to a GitHub Pages site, the final step is to ma
 
 ---
 
+## Content Requirements
+
 > [!IMPORTANT]
 > Please be aware that there are some rules that apply to website content hosted on JS.ORG subdomains:
 >


### PR DESCRIPTION
We're continuing to see an upward trend in the number of invalid requests of personal sites. I'm really not sure this will do much, but updating the PR template guidance to hopefully be that much clearer for folks that do read it.

<!--

- [x] There is reasonable content on the page (see: [No Content](https://github.com/js-org/js.org/wiki/No-Content))
- [x] I have read and accepted the [Terms and Conditions](http://js.org/terms.html)
- The site content can be seen at https://js.org

> The site content is an update to the PR template

-->