### PR TITLE
crazytools.js.org

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -704,6 +704,7 @@ var cnames_active = {
   "crawlx": "wind2sing.github.io/crawlx",
   "crawlyx": "theritikchoure.github.io/crawlyx",
   "crax": "craxjs.github.io",
+  "crazytools": "cname.vercel-dns.com", // noCF
   "crcalc": "lll69.github.io/crcalc.js",
   "creamcrop": "creamcropdev.github.io",
   "create-coffee-app": "legolovergo.github.io/create-coffee-app",


### PR DESCRIPTION
- [x] There is reasonable content on the page (see: [No Content](https://github.com/js-org/js.org/wiki/No-Content))
- [x] I have read and accepted the [Terms and Conditions](http://js.org/terms.html)
- The site content can be seen at https://crazytools-gamma.vercel.app/

> The site content is a suite of 25+ free, browser-native developer utilities (JSON formatter, Regex tester, JWT decoder, CSS specificity calculator, Hash generator, Base64 encoder, etc.) and is relevant to JavaScript developers specifically because these tools address daily workflow needs of web engineers and frontend developers. The entire toolkit is built with modern JavaScript (React 19, Vite, TanStack Start) and executes fully client-side, serving as an open-source reference for JS-native in-browser tools.