### PR TITLE
octal.js.org

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -2402,7 +2402,7 @@ var cnames_active = {
   "objectid": "the-silver-project.github.io/objectid",
   "objectmodel": "sylvainpolletvillard.github.io/ObjectModel", // noCF? (don´t add this in a new PR)
   "observable-hooks": "crimx.github.io/observable-hooks",
-  "octal": "defucc.github.io/octal-day",
+  "octal": "davay42.github.io/octal-day",
   "octofetch": "maartenvn.github.io/OctoFetch",
   "odararmy": "odararmy.github.io",
   "odialang": "cname.vercel-dns.com", // noCF`

--- a/cnames_active.js
+++ b/cnames_active.js
@@ -2402,6 +2402,7 @@ var cnames_active = {
   "objectid": "the-silver-project.github.io/objectid",
   "objectmodel": "sylvainpolletvillard.github.io/ObjectModel", // noCF? (don´t add this in a new PR)
   "observable-hooks": "crimx.github.io/observable-hooks",
+  "octal": "defucc.github.io/octal-day",
   "octofetch": "maartenvn.github.io/OctoFetch",
   "odararmy": "odararmy.github.io",
   "odialang": "cname.vercel-dns.com", // noCF`


### PR DESCRIPTION
- [x] There is reasonable content on the page (see: [No Content](https://github.com/js-org/js.org/wiki/No-Content))
- [x] I have read and accepted the [Terms and Conditions](http://js.org/terms.html)
- The site content can be seen at <https://defucc.github.io/octal-day/>

> The site content is the demo of the octal Venus transit time-keeping observational grid for planetary time representation at all scales that is just 20 LOC of bullet-proof JS code embedded right in the README.md as the single source of truth and is relevant to JavaScript developers specifically because it is a great demonstration of the JS strengths and weaknesses. It's great to see the actual `Number(73.0.toString(8))` round trip in action and to actually use the nanosecond precision `BigInt` timestamps, but also, as an example of frustrations, I've discovered that modern ESM doesn't process octal fractions natively. The demo is also published as a single file self-contained HTML web-app built with Vite. I'm now working on the exact demo content, but overall shape starts to settle as I got the backbone complete now.