### PR TITLE
repeater.js.org

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -2867,7 +2867,7 @@ var cnames_active = {
   "remote-faces": "dai-shi.github.io/remote-faces",
   "rengular": "chigix.github.io/rengular",
   "repackage": "cchamberlain.github.io/repackage", // noCF? (don´t add this in a new PR)
-  "repeater": "repeaterjs.github.io/repeater",
+  "repeater": "bikeshaving.github.io/repeater",
   "repl": "snowflyt.github.io/repl",
   "replay": "edbentley.github.io/replay",
   "reqoal": "aldhosutra.github.io/reqoal",


### PR DESCRIPTION
The repository moved from repeaterjs/repeater to bikeshaving/repeater. This PR points the `repeater` entry to the new GitHub Pages location. The Pages site is live at the new location, and the custom domain `repeater.js.org` is still configured on the repository.

I made the original registration from my old org account. I am the same owner (brainkim).

- [x] There is reasonable content on the page (see: [No Content](https://github.com/js-org/js.org/wiki/No-Content))
- [x] I have read and accepted the [Terms and Conditions](http://js.org/terms.html)
- The site content can be seen at https://repeater.js.org

> The site content is the documentation site for repeaters, and is relevant to JavaScript developers specifically because it is the documentation for Repeater, the missing constructor for creating safe async iterators. The Repeater class provides a memorable promise-based API for creating async iterators. You can reuse the same constructor to convert event targets, websockets or any other callback-based data source into a format which can be read using async/await and for await…of syntax.


