### PR TITLE
dipfs.js.org

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -847,6 +847,7 @@ var cnames_active = {
   "dime": "anut-py.github.io/dime",
   "dinesh": "dineshondev.github.io/dinesh", // noCF? (don´t add this in a new PR)
   "dinosaur": "path08.github.io/Dinosaur",
+  "dipfs": "27gscn.github.io/dipfs",
   "dipole": "zheksoon.github.io/dipole",
   "dirham": "pooyagolchian.github.io/dirham",
   "discm": "cname.vercel-dns.com", // noCF


### PR DESCRIPTION
Add subdomain dipfs.js.org for the DIPFS project (Decentralized IPFS Archive).

- Project: https://github.com/27gscn/dipfs
- Pages: https://27gscn.github.io/dipfs/
- CNAME added to target repo.