### PR TITLE
sprae.js.org

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -3221,6 +3221,7 @@ var cnames_active = {
   "spotify": "backtrackapp.github.io/spotify.js",
   "spotify-api": "spotifyapidocs.netlify.app",
   "spotistats": "spotistats-app.netlify.app",
+  "sprae": "dy.github.io/sprae",
   "spread": "spreadjs.github.io",
   "spreadsheet": "chiefofgxbxl.github.io/Spreadsheet.js",
   "spring": "hosting.gitbook.com",


### PR DESCRIPTION
- [x] There is reasonable content on the page (see: [No Content](https://github.com/js-org/js.org/wiki/No-Content))
- [x] I have read and accepted the [Terms and Conditions](http://js.org/terms.html)
- The site content can be seen at https://dy.github.io/sprae/

> The site content is the documentation site for [sprae](https://github.com/dy/sprae) — an open-source (MIT) reactive-attributes JavaScript framework for progressive enhancement of HTML — including its full directives reference, live examples, API docs, and comparison guides. It is relevant to JavaScript developers specifically because it documents a published npm JavaScript library (`npm i sprae`) that developers use to build reactive UIs, serving as the library's primary reference and learning resource.