### PR TITLE
resilix.js.org

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -2880,6 +2880,7 @@ var cnames_active = {
   "reselect": "reselect-docs.netlify.app",
   "reshape": "reshape.netlify.app",
   "reshift": "hasharray.github.io/reshift.js",
+  "resilix": "lintdeveloper.github.io/resilix",
   "rest-client": "foxifyjs.github.io/rest-client",
   "restjs": "daviesgeek.github.io/restjs", // noCF? (don´t add this in a new PR)
   "restore-scroll": "restore-scroll.netlify.app",


### PR DESCRIPTION
- [x] There is reasonable content on the page (see: [No Content](https://github.com/js-org/js.org/wiki/No-Content))
- [x] I have read and accepted the [Terms and Conditions](http://js.org/terms.html)
- The site content can be seen at https://lintdeveloper.github.io/resilix/

> The site content is the documentation for **resilix**, an open-source JavaScript resilience library — circuit breaking, adaptive concurrency limiting, retries with budgets, and hedging — and is relevant to JavaScript developers specifically because it documents a JavaScript/TypeScript npm package and the failure-handling problems it addresses in JavaScript services.

The site is an eighteen-page guide: getting started, a page per policy, the design decisions behind the library, and three design specs. Source repository: https://github.com/lintdeveloper/resilix

A note on why the library exists, since the content requirement asks what makes it relevant to this community specifically: JavaScript has plenty of fault-handling libraries, but its *load limiting* is effectively locked inside two RPC clients — hedging and retry budgets only in `@grpc/grpc-js`, adaptive throttling only in the AWS SDK — and is unavailable to anyone calling a plain HTTP API, a database or a queue. resilix implements those patterns as a zero-dependency package with no I/O, so they work anywhere JavaScript runs (Node, Bun, Deno and Cloudflare Workers, each exercised in CI).

The subdomain requested matches the repository name, per [Subdomain Determination](https://github.com/js-org/js.org/wiki/Subdomain-Determination) for a project page at `lintdeveloper.github.io/resilix`.

One sequencing note: the site is published by a GitHub Actions workflow, so a `CNAME` file in the artifact is not processed and the custom domain has to be set in the repository settings — which immediately redirects the `github.io` URL above. I have deliberately not set it yet so that the content stays reachable for review, and will set it as soon as this is approved or merged. Happy to set it beforehand if you would rather verify that way.