### PR TITLE
Add paraibajs

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -2497,6 +2497,7 @@ var cnames_active = {
   "papanasi": "witty-plant-07a086e03.1.azurestaticapps.net", // noCF
   "paperclip": "crcn.github.io/paperclip.js.org", // noCF? (don´t add this in a new PR)
   "papyrus": "papyrusjs.netlify.app",
+  "paraibajs": "cname.vercel-dns.com",
   "parallel": "parallel-js.github.io/parallel.js",
   "parametric-svg": "parametric-svg.github.io", // noCF? (don´t add this in a new PR)
   "parkrun": "prouser123.github.io/parkrun.js",


### PR DESCRIPTION
Adds paraibajs.js.org for ParaibaJS, a JavaScript community based in João Pessoa, Paraíba, Brazil. Hosted on Vercel.

Site: https://paraibajs.vercel.app

<!--

Thanks for creating a pull request to request a new subdomain from JS.ORG

⚠️ Before continuing, your site content MUST be DIRECTLY related to the JavaScript ecosystem/community
Using JavaScript on your website is not justification by itself for requesting a subdomain from JS.ORG
You must explain why your website content, not the code, is specifically relevant to other JavaScript developers

📝 Please read and complete the following steps to correctly submit your request:

- Ensure that your pull request changes only the cnames_active.js file, adding a single new line for your subdomain request
  - Follow the existing format established by the other entries, a new line with the subdomain as the key and the target hostname as the value
  - Add your new line to the file in alphabetical order, and follow the guidance given by the comments in the file itself

- Fill out this pull request template in your pull request description, maintaining the format provided to you
  - Tick the two checkboxes, agreeing to the sentences, below by placing an x inside the square brackets ([ ] becomes [x])
  - Add a link (GitHub repository, Vercel deployment, etc.), so we can review your site
  - Explain what your site content is and how it relates to the JavaScript community/ecosystem, so we can validate your request

- Ensure that your site content follows the content requirements set out in our README: https://github.com/js-org/js.org#content-requirements

-->

- [X] There is reasonable content on the page (see: [No Content](https://github.com/js-org/js.org/wiki/No-Content))
- [X] I have read and accepted the [Terms and Conditions](http://js.org/terms.html)
- The site content can be seen at <link>

> The site content is the official hub for ParaibaJS, a JavaScript community based in João Pessoa, Paraíba, Brazil. It centralizes everything needed to participate: upcoming in-person meetup events with ticket links, a Call for Papers page where developers submit talk proposals, a volunteer sign-up for people who want to help organize, and a curated list of JavaScript learning resources plus links to partner tech communities in the region. It is directly relevant to JavaScript developers because it IS the community's coordination point — not a site that merely uses JavaScript as a technology, but the hub for a real, active, in-person JS meetup (next event: September 12, 2026, with a confirmed speaker lineup and published talk schedule).
