### PR TITLE
watr.js.org

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -3780,6 +3780,7 @@ var cnames_active = {
   "watchfs": "prateekkumarweb.github.io/watchfs",
   "waterfall": "waterblock79.github.io/waterfall",
   "watermark": "fredy.github.io/watermark",
+  "watr": "dy.github.io/watr",
   "wc": "bryansha.github.io/wc",
   "wcfactory": "elmsln.github.io/wcfactory.js.org",
   "wdd": "wangduanduan.github.io",


### PR DESCRIPTION
- [x] There is reasonable content on the page (see: [No Content](https://github.com/js-org/js.org/wiki/No-Content))
- [x] I have read and accepted the [Terms and Conditions](http://js.org/terms.html)
- The site content can be seen at https://dy.github.io/watr/

> The site content is the homepage, documentation and live playground for [watr](https://github.com/dy/watr), a WAT compiler (WebAssembly text to binary) written in JavaScript and published on [npm](https://npmjs.org/watr), and is relevant to JavaScript developers specifically because it lets them compile, parse, print and optimize WebAssembly text directly from JavaScript in browsers and Node without native toolchains, with an in-browser REPL for learning and debugging wasm.