### PR TITLE
hoshimi.js.org

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -1499,6 +1499,7 @@ var cnames_active = {
   "hookstate": "hookstate.netlify.app", // noCF
   "hooloo": "hooloo.github.io", // noCF? (don´t add this in a new PR)
   "hoshii": "reinhello.github.io/hoshii-docs",
+  "hoshimi": "cname.vercel-dns.com", // noCF
   "houp": "houpjs.github.io/houp-docs",
   "hours": "cname.vercel-dns.com", // noCF
   "how-to-mithril": "stephanhoyer.github.io/how-to-mithril",


### PR DESCRIPTION
Requesting `hoshimi.js.org` for **Hoshimi** — an open-source, TypeScript-first Lavalink v4 client for Node.js.

- [x] There is reasonable content on the page.
- [x] I have read and accepted the [Terms and Conditions](https://js.org/terms.html).

- The site content can be seen at https://hoshimi-web.vercel.app

> The site content is the official documentation for Hoshimi, a Lavalink v4 client, and it is relevant to JavaScript developers specifically because it is an open-source Node.js/TypeScript library for building Discord music bots.

**Project:** https://github.com/Ganyu-Studios/hoshimi &nbsp;·&nbsp; **npm:** https://www.npmjs.com/package/hoshimi

Target is `cname.vercel-dns.com` (Vercel-managed SSL, hence `// noCF`); the domain is already added to the Vercel project so it provisions the certificate once the CNAME resolves.
