### PR TITLE
register atlas.js.org

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -273,6 +273,7 @@ var cnames_active = {
   "atenas": "atenasjs.netlify.app",
   "athena": "athena-js.github.io/athena",
   "athome": "simon300000.github.io/athome",
+  "atlas": "superbibop.github.io/atlas",
   "atom": "atom-js-org.github.io/website",
   "atombundles": "lirantal.github.io/atombundles",
   "atomicreact": "atomicreact.github.io/AtomicReact",


### PR DESCRIPTION
Requesting **atlas.js.org** for https://superbibop.github.io/atlas/ — atlas, a student term planner & deadline-cascading PWA (React + TypeScript). Site is live and served over the target now.