### PR TITLE
spreaddebate.js.org

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -3230,6 +3230,7 @@ var cnames_active = {
   "spotistats": "spotistats-app.netlify.app",
   "sprae": "dy.github.io/sprae",
   "spread": "spreadjs.github.io",
+  "spreaddebate": "wowneutral.github.io/spread",
   "spreadsheet": "chiefofgxbxl.github.io/Spreadsheet.js",
   "spring": "hosting.gitbook.com",
   "spritesheet": "arcadiogarcia.github.io/Spritesheet.js", // noCF? (don´t add this in a new PR)


### PR DESCRIPTION
- [x] There is reasonable content on the page (see: [No Content](https://github.com/js-org/js.org/wiki/No-Content))
- [x] I have read and accepted the [Terms and Conditions](http://js.org/terms.html)
- The site content can be seen at https://wowneutral.github.io/spread/

> The site content is Spread, a free, MIT-licensed, open-source card-cutting editor for competitive debate that runs entirely in the browser — the site is the app itself, live and usable. It is relevant to JavaScript developers specifically because it is a substantial TypeScript project built on ProseMirror that implements lossless client-side OOXML (.docx) round-tripping with no server, including a from-scratch importer/exporter and file-driven style rendering — the source at https://github.com/wowneutral/spread is a working reference for anyone building document editors in JS.