### PR TITLE
adjskit.js.org

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -3954,7 +3954,8 @@ var cnames_active = {
   "zykj": "cname.vercel-dns.com", // noCF
   "zylog": "cname.vercel-dns.com", // noCF
   "zyx": "zyx.alwaysdata.net",
-  "zyy": "zyyou.github.io/notes"
+  "zyy": "zyyou.github.io/notes",
+  "adjskit": "devs-des1re.github.io/adjskit"
   /*
    * please don't add your subdomain records down here!
    * insert them in alphabetical order to help reduce merge conflicts.

--- a/cnames_active.js
+++ b/cnames_active.js
@@ -106,6 +106,7 @@ var cnames_active = {
   "aderemi": "aderemi.github.io",
   "adil": "adilzeshan.github.io/adil",
   "aditya": "aditya81070.github.io",
+  "adjskit": "devs-des1re.github.io/adjskit",
   "adnanbabakan": "adnanbabakan.github.io",
   "adon988": "adon988.github.io",
   "adv": "advjs.github.io",
@@ -3954,8 +3955,7 @@ var cnames_active = {
   "zykj": "cname.vercel-dns.com", // noCF
   "zylog": "cname.vercel-dns.com", // noCF
   "zyx": "zyx.alwaysdata.net",
-  "zyy": "zyyou.github.io/notes",
-  "adjskit": "devs-des1re.github.io/adjskit"
+  "zyy": "zyyou.github.io/notes"
   /*
    * please don't add your subdomain records down here!
    * insert them in alphabetical order to help reduce merge conflicts.


### PR DESCRIPTION
- [x] There is reasonable content on the page (see: [No Content](https://github.com/js-org/js.org/wiki/No-Content))
- [x] I have read and accepted the [Terms and Conditions](http://js.org/terms.html)
- The site content can be seen at https://devs-des1re.github.io/adjskit/

> The site content is the official documentation website for adjskit, an open-source discord.js v14 framework and CLI that unifies slash and prefix commands with signed interactive components, typed events, built-in cooldowns, and database presets, and is relevant to JavaScript developers specifically because it provides in-depth technical guides, API references, configuration walkthroughs, and developer workflows for building Discord bots in JavaScript and TypeScript on Node.js and the discord.js ecosystem.
