### PR TITLE
kikirach.js.org

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -1759,6 +1759,7 @@ var cnames_active = {
   "keyvify": "zyrouge.github.io/Keyvify",
   "kfg": "drysius.github.io/kfg",
   "kickstack": "cname.vercel-dns.com", // noCF
+  "kikirach": "cname.vercel-dns.com", // noCF
   "kilobyte": "kilobytehq.github.io/open-js",
   "kilvin": "rofrischmann.github.io/kilvin",
   "kim": "khareemnurulla.github.io/kim",


### PR DESCRIPTION
### Requested Subdomain
- `kikirach.js.org`

### Target
- Pointing to: `cname.vercel-dns.com` (noCF)
- Production URL: `https://kikirach.vercel.app`
- Project: Film producer & filmmaker portfolio web app (Next.js / React)

### Ownership / Project
- Repository: https://github.com/frahmat68-beep/Portofolio
- Owner: @frahmat68-beep
