### PR TITLE
welcomescore.js.org

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -3819,6 +3819,7 @@ var cnames_active = {
   "wedgetail": "wedgetail.netlify.app",
   "weekly": "xdimh.github.io/weekly",
   "welcome": "edapm.github.io/welcomejs",
+  "welcomescore": "cname.vercel-dns.com",
   "welson": "gnh1201.github.io/welsonjs",
   "wepl": "obnoxiousnerd.github.io/wepl-website",
   "wfplayer": "zhw2590582.github.io/WFPlayer",


### PR DESCRIPTION
WelcomeScore is a free tool that scores how welcoming a GitHub 
repository is to first-time open-source contributors — checking for 
things like a CONTRIBUTING guide, a code of conduct, and 
beginner-friendly issue labels. Built with Next.js, hosted on Vercel.

Live at: https://welcomescore.vercel.app/