### PR TITLE
halloween.js.org

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -1438,6 +1438,7 @@ var cnames_active = {
   "hahuutin": "hahuutin.github.io",
   "hale": "haleshaw.github.io/hale",
   "halil": "hibrahimsafak.github.io", // noCF? (don´t add this in a new PR)
+  "halloween": "rogulia.github.io/halloween.js",
   "haloapi": "derflatulator.github.io/haloapi.js", // noCF? (don´t add this in a new PR)
   "hamburger-menu": "center-key.github.io/hamburger-menu",
   "hamed": "phpniki.github.io/hamed",


### PR DESCRIPTION
- [x] There is reasonable content on the page (see: [No Content](https://github.com/js-org/js.org/wiki/No-Content))
- [x] I have read and accepted the [Terms and Conditions](http://js.org/terms.html)
- The site content can be seen at https://rogulia.github.io/halloween.js/

> The site content is the landing page, live configurator, and documentation for halloween.js, a zero-dependency JavaScript library that adds opt-in screen-corner webs and ambient Halloween effects — blinking cat eyes, flying witches, a dropping spider, and rising tombstones — to any website. It is relevant to JavaScript developers specifically because it is a published npm package with installation instructions, a configurator, live preview, and API documentation.

---

Requested domain: `halloween.js.org`

- Project: halloween.js
- Repository: https://github.com/rogulia/halloween.js
- Current GitHub Pages deployment: https://rogulia.github.io/halloween.js/
- npm: https://www.npmjs.com/package/halloween.js
- Latest release: https://github.com/rogulia/halloween.js/releases/tag/v1.0.1

The GitHub Pages custom domain (`halloween.js.org`) has already been set via repository Settings/Pages API. Deployment is handled by a GitHub Actions workflow, so no `CNAME` file is present in the repository, per the current JS.ORG instructions for workflow-based Pages deployments.
