### PR TITLE
resilix.js.org

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -2886,6 +2886,7 @@ var cnames_active = {
   "reselect": "reselect-docs.netlify.app",
   "reshape": "reshape.netlify.app",
   "reshift": "hasharray.github.io/reshift.js",
+  "resilix": "lintdeveloper.github.io/resilix",
   "rest-client": "foxifyjs.github.io/rest-client",
   "restjs": "daviesgeek.github.io/restjs", // noCF? (don´t add this in a new PR)
   "restore-scroll": "restore-scroll.netlify.app",


### PR DESCRIPTION
- [x] There is reasonable content on the page (see: [No Content](https://github.com/js-org/js.org/wiki/No-Content))
- [x] I have read and accepted the [Terms and Conditions](http://js.org/terms.html)
- The site content can be seen at https://github.com/lintdeveloper/resilix (and, once DNS resolves, at the subdomain itself)

> The site content is the documentation for **resilix**, an open-source JavaScript resilience library — adaptive concurrency limiting, circuit breaking, retries with budgets and hedging — and is relevant to JavaScript developers specifically because it documents a published npm package and the failure-handling problems it addresses in JavaScript services.

**The custom domain is now configured**, as requested on my earlier attempt (#12312). Repository settings → Pages → Custom domain is set to `resilix.js.org`, and the site build has `base: "/"` so it serves correctly from the subdomain root. Because a `CNAME` file in the artifact is ignored when publishing via a GitHub Actions workflow, this had to be set in the repository settings — which means `lintdeveloper.github.io/resilix` now 301-redirects to `resilix.js.org` and cannot serve the content until this entry is merged.

Apologies for #12312 — the domain request was correct but I did not respond to the review comment in time, and it was closed for inactivity. That was my fault. I am watching this one.

The site is an eighteen-page guide: getting started, a page per policy, the design decisions behind the library, a map from each source file to the paper it implements, and three design specs. It is a real published package — [`resilix` on npm](https://www.npmjs.com/package/resilix), currently 0.5.1, MIT, zero runtime dependencies, published with provenance.

For the content-relevance requirement: JavaScript has plenty of fault-handling libraries, but its *load limiting* is effectively locked inside two RPC clients — hedging and retry budgets only in `@grpc/grpc-js`, adaptive throttling only in the AWS SDK — and is unavailable to anyone calling a plain HTTP API, a database or a queue. resilix implements those patterns as a zero-dependency package with no I/O, so they work anywhere JavaScript runs; Node 18/20/22/24, Bun, Deno and Cloudflare Workers are each exercised in CI against the built artifact.

The subdomain requested matches the repository name, per [Subdomain Determination](https://github.com/js-org/js.org/wiki/Subdomain-Determination) for a project page at `lintdeveloper.github.io/resilix`.

Happy to make any change you need — please just say so and I will respond promptly.