### PR TITLE
daggerfall.js.org

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -758,6 +758,7 @@ var cnames_active = {
   "cyris": "icyris.github.io",
   "d-patterns": "alias.zeit.co", // noCF
   "d4": "joelburget.github.io/d4",
+  "daggerfall": "lattymoy.github.io/project-dagger",
   "daily.tmr": "tmr-daily.netlify.app", // noCF
   "daisy": "warengonzaga.github.io/daisy.js",
   "daksh0225": "daksh0225.github.io",

--- a/cnames_active.js
+++ b/cnames_active.js
@@ -758,7 +758,7 @@ var cnames_active = {
   "cyris": "icyris.github.io",
   "d-patterns": "alias.zeit.co", // noCF
   "d4": "joelburget.github.io/d4",
-  "daggerfall": "lattymoy.github.io/project-dagger",
+  "daggerfall": "lattymoy.github.io/daggerfall-js-source",
   "daily.tmr": "tmr-daily.netlify.app", // noCF
   "daisy": "warengonzaga.github.io/daisy.js",
   "daksh0225": "daksh0225.github.io",


### PR DESCRIPTION
- [x] There is reasonable content on the page (see: [No Content](https://github.com/js-org/js.org/wiki/No-Content))
- [x] I have read and accepted the [Terms and Conditions](http://js.org/terms.html)
- The site content can be seen at <https://lattymoy.github.io/daggerfall-js-source/>

> The content is the home of Daggerfall JavaScript, an open-source, from-scratch JavaScript port of the 1996 game Daggerfall (about 120,000 lines of ES modules with a hand-rolled WebGL2 renderer, no engine or framework, source at https://github.com/Lattymoy/daggerfall-js-source), covering what the project is, how it is built, how to run it, the controls, the credits, and the game itself under /play/, and it is relevant to JavaScript developers specifically because it is a large, tested, plain-JavaScript codebase that shows how a full 3D game with a decade of game logic is written for the browser in JS - WebGL2 rendering, a WebAudio FM synthesizer for the music, IndexedDB for the player's own game files, binary format readers, ES modules throughout - with the design documents and a 3,500-test suite in the repository for anyone to read and reuse.

The site publishes with a GitHub Actions workflow, so the custom domain will be set in the repository's Pages settings (rather than a CNAME file) as soon as this is merged. The subdomain is the project's public name, Daggerfall JavaScript; the repository is `daggerfall-js-source`.
