### PR TITLE
kmenta.js.org / kmta.kmenta.js.org

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -1777,7 +1777,7 @@ var cnames_active = {
   "klepto": "mwjaworski.github.io/klepto",
   "kloner": "fivefifteen.github.io/kloner",
   "kmeans": "jeff-tian.github.io/k-means",
-  "kmenta": "kc.kang0234.top",
+  "kmenta": "kcomment.pages.dev", // noCF
   "knc": "chaituknag.github.io",
   "ko": "ko25july.github.io/ko.js.org",
   "ko.mobx": "cname.vercel-dns.com", // noCF

--- a/cnames_active.js
+++ b/cnames_active.js
@@ -1777,6 +1777,7 @@ var cnames_active = {
   "klepto": "mwjaworski.github.io/klepto",
   "kloner": "fivefifteen.github.io/kloner",
   "kmeans": "jeff-tian.github.io/k-means",
+  "kmenta": ["olivia.ns.cloudflare.com", "rommy.ns.cloudflare.com"],
   "knc": "chaituknag.github.io",
   "ko": "ko25july.github.io/ko.js.org",
   "ko.mobx": "cname.vercel-dns.com", // noCF

--- a/cnames_active.js
+++ b/cnames_active.js
@@ -1777,7 +1777,7 @@ var cnames_active = {
   "klepto": "mwjaworski.github.io/klepto",
   "kloner": "fivefifteen.github.io/kloner",
   "kmeans": "jeff-tian.github.io/k-means",
-  "kmenta": ["olivia.ns.cloudflare.com", "rommy.ns.cloudflare.com"],
+  "kmenta": "kc.kang0234.top",
   "knc": "chaituknag.github.io",
   "ko": "ko25july.github.io/ko.js.org",
   "ko.mobx": "cname.vercel-dns.com", // noCF

--- a/cnames_active.js
+++ b/cnames_active.js
@@ -1778,6 +1778,7 @@ var cnames_active = {
   "kloner": "fivefifteen.github.io/kloner",
   "kmeans": "jeff-tian.github.io/k-means",
   "kmenta": "kcomment.pages.dev", // noCF
+  "kmta.kmenta": "kcomment.pages.dev", // noCF
   "knc": "chaituknag.github.io",
   "ko": "ko25july.github.io/ko.js.org",
   "ko.mobx": "cname.vercel-dns.com", // noCF


### PR DESCRIPTION
- [x] There is reasonable content on the page (see: [No Content](https://github.com/js-org/js.org/wiki/No-Content))
- [x] I have read and accepted the [Terms and Conditions](http://js.org/terms.html)
- The site content can be seen at <https://kc.kang0234.top>

> The site content is a documentation and live-demo site for **kmenta**, an MIT-licensed, privacy-first comment system for JavaScript-powered sites (blogs built with Hexo/Vite/Next, docs of open-source JS projects, community pages), and is relevant to JavaScript developers specifically because the entire content teaches and demonstrates JavaScript integration: copy-paste embed snippets for static blogs and SPAs, `kcomment.init()` usage examples for React/Vue routing, and deployment walkthroughs for the JS stack it ships with (Node.js/Express, Cloudflare Pages Functions on the Workers runtime with D1/R2, Vercel + MongoDB). The comment widget embedded at the bottom of the page is the very vanilla-JS artifact the project distributes — every visitor interacts with a live, working demo rather than a landing page.

---

**Project:** [Kang0234/KComment](https://github.com/Kang0234/KComment) · MIT
**Requested subdomain:** `kmenta` → `"kmenta": "kc.kang0234.top"` (CNAME entry already committed on branch `kmenta`)

Thanks for reviewing! Happy to adjust anything. 🙏