### PR TITLE
welcomescore.js.org

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -3821,6 +3821,7 @@ var cnames_active = {
   "wedgetail": "wedgetail.netlify.app",
   "weekly": "xdimh.github.io/weekly",
   "welcome": "edapm.github.io/welcomejs",
+  "welcomescore": "cname.vercel-dns.com", // noCF
   "welson": "gnh1201.github.io/welsonjs",
   "wepl": "obnoxiousnerd.github.io/wepl-website",
   "wfplayer": "zhw2590582.github.io/WFPlayer",


### PR DESCRIPTION
- [x] There is reasonable content on the page (see: [No Content](https://github.com/js-org/js.org/wiki/No-Content))
- [x] I have read and accepted the [Terms and Conditions](http://js.org/terms.html)
- The site content can be seen at https://welcomescore.vercel.app/js

> The site content is a public JavaScript and TypeScript maintainer dashboard with a matching CLI package at https://www.npmjs.com/package/@ethiorhq/welcomescore. It is relevant to JavaScript developers specifically because it gives npm package maintainers transparent, deterministic checks for package metadata, TypeScript and Node tooling, CI workflow evidence, and contributor foundations; developers can also run it locally with npx @ethiorhq/welcomescore.

The dashboard is substantive and read-only. The local-first CLI does not upload project source files, manifests, environment values, or repository credentials. Source, tests, package metadata, and the release workflow are available at https://github.com/ethiorhq/welcomescore/tree/main/packages/cli.