### PR TITLE
prodcheck.js.org

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -2648,6 +2648,7 @@ var cnames_active = {
   "prettylog": "moosecoop.github.io/PrettyLog",
   "printx": "x-ext.netlify.app",
   "pristine": "sha256.github.io/Pristine", // noCF
+  "prodcheck": "farzamhabibi.github.io/pre-production-checklist",
   "producify": "jesobreira.github.io/producify",
   "producthunt-trending": "xiaomingplus.github.io/producthunt-trending",
   "profanity-finder": "gautamkrishnar.github.io/profanity-finder.js",


### PR DESCRIPTION
- [x] There is reasonable content on the page (see: [No Content](https://github.com/js-org/js.org/wiki/No-Content))
- [x] I have read and accepted the [Terms and Conditions](http://js.org/terms.html)
- The site content can be seen at https://farzamhabibi.github.io/pre-production-checklist/

> The site content is a set of pre-production checklists — 4,124 things to verify before shipping a web product, across security, performance, scale, integrations and incident readiness — and is relevant to JavaScript developers specifically because a large part of the content is about the JavaScript and Node ecosystem itself, not merely written in it.

Concretely, and countable from the site:

| Content | Items |
| --- | ---: |
| [JavaScript performance](https://farzamhabibi.github.io/pre-production-checklist/c/performance--04-javascript.html) — bundle analysis, code splitting, tree shaking and `sideEffects`, hydration cost, long tasks on the main thread, web workers, third-party script facades | 43 |
| [Loading and the critical path](https://farzamhabibi.github.io/pre-production-checklist/c/performance--03-loading-and-critical-path.html) — `defer`/`async`, `modulepreload`, module/nomodule, `document.write`, bfcache eligibility | 37 |
| [CI/CD and supply chain](https://farzamhabibi.github.io/pre-production-checklist/c/security--core--15-ci-cd-and-supply-chain.html) — `npm audit`, lockfile integrity, transitive dependencies, install scripts, publishing | 158 |
| Framework supplements: [Next.js / React](https://farzamhabibi.github.io/pre-production-checklist/c/stacks--nextjs-react.html), [Express](https://farzamhabibi.github.io/pre-production-checklist/c/stacks--express.html), [NestJS](https://farzamhabibi.github.io/pre-production-checklist/c/stacks--nestjs.html), [React Native](https://farzamhabibi.github.io/pre-production-checklist/c/stacks--react-native.html) — Server Components, `next/image`, `dangerouslySetInnerHTML`, `helmet()`, Express body limits, NestJS DTO validation, Metro/Hermes | 86 |

Those pages name things a JavaScript developer greps their own repository for, and they are the reason a JS developer would visit rather than a general audience.

The project is also distributed as the npm package [`prodcheck`](https://www.npmjs.com/package/prodcheck) — a zero-dependency Node CLI and an MCP server — and the site is its documentation. I mention that second deliberately, since I understand from the template that shipping on npm is not on its own a reason to grant a subdomain.

Repository: https://github.com/FarzamHabibi/pre-production-checklist
Licence: content CC BY 4.0, code MIT. No ads, no tracking, no sign-up.

Happy to withdraw if you judge the balance of content too general for JS.ORG.
