### PR TITLE
JS.ORG CLEANUP (#12043)

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -74,7 +74,6 @@ var cnames_active = {
   "ab64": "un-ts.github.io/ab64",
   "abbw": "abbw.github.io",
   "abbyz": "abbyzhoum.github.io",
-  "abcdb": "hosting.gitbook.com", // noCF
   "abdalla": "the94air.github.io/abdalla",
   "abelacostaportafolio": "asaa19971a.github.io/AbelAcostaAcostaPortafolio",
   "abhishek": "rpidanny.github.io/personal-collage",
@@ -85,7 +84,6 @@ var cnames_active = {
   "abracadabra": "doc-cgg.pages.dev",
   "aby": "icoldplayer.github.io/aby",
   "ac": "alauda.github.io/alauda-chart",
-  "acarsy": "acarsy.github.io",
   "accent": "sripkunda.github.io/accent",
   "accessibility": "guilhermedelemos.github.io/accessibility",
   "accordion": "awps.github.io/Accordion.JS",
@@ -93,7 +91,6 @@ var cnames_active = {
   "acegroup": "mohamed0group.github.io/acegroup",
   "acho": "achojs.github.io/acho",
   "acidmod": "acidmod.github.io",
-  "acker": "acker-technologies.github.io/ackerjs",
   "acm": "drew233.github.io/calander",
   "acme": "makepost.github.io/acme-commander",
   "action-u": "kevinast.github.io/action-u",
@@ -116,7 +113,6 @@ var cnames_active = {
   "affiliate": "russellsteadman.github.io/affiliate",
   "affinityhub": "s1m0np1.github.io/affinity-script-installer",
   "afilters": "dmytrohoi.github.io/afilters.js",
-  "afmsavage": "afmsavage.github.io",
   "afterwind": "eedrxs.github.io/afterwind",
   "agahi": "teneplaysofficial.github.io/agahi",
   "agenda-tech-brasil-site": "abacatinhos.github.io/agenda-tech-brasil-site",
@@ -196,8 +192,6 @@ var cnames_active = {
   "angular-jsf": "json-schema-faker.github.io/angular-jsf", // noCF? (don´t add this in a new PR)
   "angular-mfe": "rx-ts.github.io/angular-mfe",
   "angular-redux": "angular-redux-docs.netlify.app", // noCF
-  "angular-uikit": "whoisjorge.github.io/angular-uikit",
-  "angular2in1": "angular2in1.github.io/angular2in1js", // noCF
   "angularstompdk": "davinkevin.github.io/AngularStompDK", // noCF? (don´t add this in a new PR)
   "ani-client": "cname.vercel-dns.com", // noCF
   "anilist": "instellate.github.io/anilist.js",
@@ -255,11 +249,9 @@ var cnames_active = {
   "arthurmbandeira": "arthurmbandeira.github.io",
   "artificial": "fabiosmuu.github.io/artificial",
   "artitalk": "artitalkjs.github.io/docs",
-  "asdivyansh": "asdivyansh.github.io",
   "aspectly": "jeanisahakyan.github.io/aspectly",
   "ass": "weizhenye.github.io/ASS",
   "ass-editor": "jeff-tian.github.io/ass",
-  "assay": "assay-ai.github.io/assay",
   "assembly-line": "rubenverg.github.io/assembly-line.js",
   "assistant": "coolmlgplayer-js.github.io",
   "ast": "kindy.github.io/ast",
@@ -290,13 +282,11 @@ var cnames_active = {
   "autodocs": "bguiz.github.io/autodocs", // noCF? (don´t add this in a new PR)
   "automata": "cname.vercel-dns.com", // noCF
   "automic": "automicjs.github.io",
-  "avg": "biyuehu.github.io/avgjs",
   "avi": "avinassh.github.io/avi", // noCF? (don´t add this in a new PR)
   "avner": "avnerus.github.io", // noCF? (don´t add this in a new PR)
   "avo": "benjaminbhollon.github.io/avo-js",
   "avstream": "akash-joshi.github.io/avstream.js",
   "awai": "cname.vercel-dns.com", // noCF
-  "awardify": "cname.vercel-dns.com", // noCF
   "awesome-alexa": "dolanmiu.github.io/MMM-awesome-alexa",
   "awesome-javascript": "kungfu321.github.io/awesome-javascript",
   "awesome-nuxt": "ansidev.github.io/awesome-nuxt",
@@ -311,13 +301,11 @@ var cnames_active = {
   "axios-cache-interceptor": "arthurfiorette.github.io/axios-cache-interceptor",
   "axios-cache-lite": "nom-nom-hub.github.io/axios-cache-lite",
   "axon": "caracal7.github.io/axon.js",
-  "azbuka-vkusa": "bullwinkle.github.io/azbuka-vkusa",
   "aziz": "iaziz786.netlify.app",
   "azlyrics-ext": "zyrouge.github.io/azlyrics-ext",
   "azura": "hosting.discloud.app", // noCF
   "azurajs-scalar": "d3veduardo.github.io/azurajs-scalar",
   "azurapi": "azurapi.github.io/azurapi-js",
-  "bachors": "bachors.github.io",
   "backlog": "backlog-js.github.io/backlog.js.org", // noCF? (don´t add this in a new PR)
   "backolon": "r47onfire.github.io/backolon",
   "backstage": "backstagejs.github.io/backstage",
@@ -327,7 +315,6 @@ var cnames_active = {
   "badonker": "redsplit.github.io/badonker",
   "badrudeen": "badrudeen.github.io", // noCF? (don´t add this in a new PR)
   "bahrain": "bahrain-js.github.io/bahrain.js",
-  "baicai": "zibaicai.github.io/baicaijsorg",
   "bakhtiyar": "bakszero.github.io",
   "bali": "balijs.github.io",
   "balm": "balmjs.github.io/balm.js.org",
@@ -447,7 +434,6 @@ var cnames_active = {
   "brigsby": "tynatsuhara.github.io/brigsby",
   "brizusan": "blackmyab.github.io/brizusan",
   "brotat": "mariobob.github.io/brotat-website",
-  "browse4extact": "browse4extract.github.io/b4e-website",
   "browser-ocr": "oshekharo.github.io/Browser-OCR",
   "browserless": "microlinkhq.github.io/browserless",
   "brum": "romantic-noyce-67d6ee.netlify.app",
@@ -455,7 +441,6 @@ var cnames_active = {
   "bt": "mldonkey.github.io/bt",
   "bud": "roots-bud.netlify.app",
   "bui": "kjantzer.github.io/bui",
-  "builders": "cname.vercel-dns.com", // noCF
   "bullwinkle": "bullwinkle.github.io",
   "bun": "the94air.github.io/bun",
   "bundle": "cname.vercel-dns.com", // noCF
@@ -484,12 +469,10 @@ var cnames_active = {
   "cachi": "eddiejibson.github.io/cachi",
   "cacophony": "ctoth.github.io/cacophony",
   "caffeine": "ccrraaiigg.github.io/caffeine",
-  "caicai": "qianxunclub.github.io/CaiCai",
   "caissa": "agentx-cgn.github.io/caissa",
   "caizhiyuannn": "caizhiyuannn.github.io",
   "calcium": "courageous-bublanina-6857c1.netlify.app",
   "calcy": "odevlord.github.io/Calcy", // noCF? (don´t add this in a new PR)
-  "calisto": "cname.vercel-dns.com", // noCF
   "camelcase": "ultirequiem.github.io/camelcase",
   "campfire": "xyzshantaram.github.io/campfire",
   "candy": "candy02058912.github.io/portfolio",
@@ -524,11 +507,9 @@ var cnames_active = {
   "cartodb-demo": "opensas.github.io/cartodb-demo", // noCF? (don´t add this in a new PR)
   "casl": "stalniy.github.io/casl",
   "cassie": "milesgitgud.github.io/cassie",
-  "castyte": "bbe51df3-e739-437e-92c1-e62d3ac67039.pages.dev", // noCF
   "catbox": "samsamson33.github.io/catbox.js",
   "cath": "cath-docs.pages.dev", // noCF
   "catisol": "catisol-ui.netlify.app",
-  "cats": "whoisjorge.github.io/not-cat-gifs",
   "cavojmidi": "cavojmidi.netlify.app",
   "cbm": "cbmjs.github.io/cbm-website",
   "cdc-bot": "cdc-bot-js-npm.github.io/website",
@@ -557,19 +538,16 @@ var cnames_active = {
   "chenyuhu": "chenyuhu.github.io",
   "chernivtsi": "chernivtsijs.github.io",
   "chess-barebones": "iamawebgeek.github.io/chess-barebones",
-  "chig": "eliotchignell.github.io",
   "chirashi": "chirashijs.github.io/chirashi",
   "chitchat": "chitchatjs.github.io",
   "choo": "choo-js.github.io",
   "chordthing": "ifons42.github.io/chordthing",
   "chris": "christopher-hayes.github.io/chris",
   "chrismendis": "chrismendis.github.io", // noCF? (don´t add this in a new PR)
-  "christo": "christoga.github.io/js-org", // noCF? (don´t add this in a new PR)
   "christopher": "marekkobida.github.io/christopher",
   "chronos": "espinielli.github.io/chronos", // noCF? (don´t add this in a new PR)
   "chronosis": "jack-weilage.github.io/chronosis",
   "citation": "citation-js.github.io/site",
-  "cite": "citecount.netlify.app",
   "citeapa": "natsuozawa.github.io/citeapa",
   "city": "city.github.io",
   "civet": "civet-org.github.io",
@@ -586,7 +564,6 @@ var cnames_active = {
   "cleaners": "swansontec.github.io/cleaners",
   "clearlyelevated": "clearlyelevated.github.io",
   "clerc": "apex-loadbalancer.netlify.app",
-  "clevercord": "theanidox.github.io/Clevercord",
   "clickforhelp": "clickforhelp.netlify.app",
   "clickhouse": "depyronick.github.io/clickhouse-client",
   "clientworker": "chenyfan.github.io/ClientWorker",
@@ -609,7 +586,6 @@ var cnames_active = {
   "cobalt-kit": "bernzrdo.github.io/cobalt-kit",
   "cocy": "krmax44.github.io/cocy",
   "code-tour": "code-tour.netlify.app",
-  "codeberry": "cname.vercel-dns.com", // noCF
   "codebooky": "hiteshsubnani0128.github.io/codebooky",
   "codemade": "codemade.github.io", // noCF? (don´t add this in a new PR)
   "codemirror-languageservice": "codemirror-languageservice.netlify.app",
@@ -698,7 +674,6 @@ var cnames_active = {
   "cpp": "bugra9.github.io/cpp.js",
   "cppkies": "cppkies-team.github.io/Cppkies",
   "cq-websocket": "momocow.github.io/node-cq-websocket",
-  "cqrs": "adrai.github.io/cqrs", // noCF? (don´t add this in a new PR)
   "cr": "echosoar.github.io/cr",
   "crackabottle": "crack-a-bottle.github.io",
   "cracked": "billorcutt.github.io/Cracked",
@@ -706,7 +681,6 @@ var cnames_active = {
   "craft": "cname.vercel-dns.com", // noCF
   "crank": "bikeshaving.github.io/crank",
   "crapto1": "li0ard.github.io/crapto1_ts",
-  "crawlx": "wind2sing.github.io/crawlx",
   "crawlyx": "theritikchoure.github.io/crawlyx",
   "crax": "craxjs.github.io",
   "crcalc": "lll69.github.io/crcalc.js",
@@ -867,7 +841,6 @@ var cnames_active = {
   "discord-components": "skyra-project.github.io/discord-components",
   "discord-easy-leveling": "retrouser955.github.io/discord-easy-leveling",
   "discord-easy-slash": "amukh1.github.io/discord-easy-slash",
-  "discord-gamecord": "cname.vercel-dns.com", // noCF
   "discord-giveaways": "androz2091.github.io/discord-giveaways",
   "discord-kommando": "team-thinkcord.github.io/discord-kommando.js",
   "discord-kommando-plugins": "team-thinkcord.github.io/discord-kommando.js-plugins",
@@ -1085,7 +1058,6 @@ var cnames_active = {
   "epoxylang": "iamsatyanchal.github.io/epoxylang",
   "eq8": "eq8.github.io",
   "eqeq": "slikts.github.io/js-equality-game",
-  "er-api-sdk": "erbots.github.io/Er-Api-Sdk",
   "eray": "erayarslan.github.io", // noCF? (don´t add this in a new PR)
   "erdem": "erdem85.github.io",
   "erebos": "mainframehq.github.io/erebos",
@@ -1093,7 +1065,6 @@ var cnames_active = {
   "eren": "eren885.github.io",
   "erest": "yourtion.github.io/node-erest",
   "erikng": "eriknguyen.github.io",
-  "erin": "blstmo-abandoned-us-for-the-milk.github.io/docs",
   "erine": "cyberghxst.github.io/erine-docs",
   "ero": "mst-2.github.io/ero",
   "erpeel": "fikriks.github.io/erpeel",
@@ -1103,7 +1074,6 @@ var cnames_active = {
   "es.redux": "sergiodxa.github.io/redux-in-spanish", // noCF? (don´t add this in a new PR)
   "es.single-spa": "single-spa.github.io/es.single-spa.js.org", // noCF
   "es2015-node": "martinheidegger.github.io/es6modules-nodejs", // noCF? (don´t add this in a new PR)
-  "es6-module-seed": "blackmirror1980.github.io/es6-module-seed",
   "esbin": "esbin.netlify.app",
   "esboot": "moonlitusun.github.io/esboot",
   "escape": "licshee.github.io/Escape.js", // noCF? (don´t add this in a new PR)
@@ -1132,7 +1102,6 @@ var cnames_active = {
   "exbars": "youssefkababe.github.io/exbars", // noCF? (don´t add this in a new PR)
   "excmd": "elliottcable.github.io/excmd.js",
   "executor": "executor.netlify.app",
-  "exeform": "hosting.gitbook.com", // noCF
   "exome": "exome.pages.dev", // noCF
   "exp": "magicops.github.io/JQuery-expression-builder",
   "expass": "expass.github.io/expass",
@@ -1153,11 +1122,9 @@ var cnames_active = {
   "facepalm": "santiagogil.github.io/facepalm",
   "facreative": "facreative.github.io",
   "fairy": "fairymeee.github.io",
-  "fakeyou": "leunamcrack.github.io/fakeyou.js",
   "fakeyouapi": "ftk789.github.io/FakeYouAPI.js",
   "fakeyouts": "jack3898.github.io/fakeyou.ts",
   "fallr": "faisalman.github.io/fallr-js",
-  "fan": "garychamberlain.github.io/fan",
   "fanbook-api-sdk": "fanbook-api-node-sdk.netlify.app",
   "fanbook-mp-sdk": "fanbook-mp-sdk.netlify.app",
   "fancy-pants": "fancy-pants.tritarget.org",
@@ -1208,7 +1175,6 @@ var cnames_active = {
   "flaregram": "adityash4rma.github.io/flaregram-website",
   "flash": "flashcardjs.github.io",
   "flatpickr": "flatpickr.github.io",
-  "flavor": "blackmirror1980.github.io/flavor-js",
   "fld-grd": "mrksbnch.github.io/fld-grd",
   "flightpkg": "cname.vercel-dns.com", // noCF
   "flipnote": "jaames.github.io/flipnote.js",
@@ -1261,7 +1227,6 @@ var cnames_active = {
   "freezer": "pakastin.github.io/freezer",
   "frint": "frintjs.github.io/frint.js.org",
   "fritzbox": "lesander.github.io/fritzbox.js",
-  "front-end": "whoisjorge.github.io/front-end",
   "frontik": "fluxtech-me.github.io/frontik",
   "frontless": "nesterow.github.io/frontless",
   "fronts": "unadlib.github.io/fronts",
@@ -1279,7 +1244,6 @@ var cnames_active = {
   "funcs": "funcs-package.github.io/docs",
   "fusilli": "anthemaker.github.io/Fusilli.js",
   "fvuar": "fvuarjs.netlify.app",
-  "fw": "fjs.alwaysdata.net",
   "fy": "fyjs.netlify.app",
   "fyi": "tobihrbr.github.io/fyi",
   "g": "nodebox.github.io/g.js",
@@ -1335,7 +1299,6 @@ var cnames_active = {
   "git-terminal": "jcubic.github.io/git",
   "git0": "vtempest.github.io/git0",
   "gitbanner": "asheeeshh.github.io/gitbanner",
-  "gitcrate": "gitcrate.github.io",
   "gitdown": "gc.github.io/gitdown",
   "githubtouch": "github-touch.github.io",
   "gitinit": "silly-shirley-8e44e3.netlify.app",
@@ -1350,7 +1313,6 @@ var cnames_active = {
   "glicol": "glicol-js.netlify.app",
   "glitchapi": "cname.vercel-dns.com", // noCF
   "glitchy-scratch": "glitchy-scratch.github.io",
-  "glitterbot": "glitterbot.netlify.app", // noCF
   "glize": "datamart.github.io/Glize",
   "globalart": "globalartinc.github.io/ecosystem",
   "globx": "aminadav.github.io/globx",
@@ -1404,13 +1366,11 @@ var cnames_active = {
   "guard-sdk": "apvarun.github.io/guard-sdk",
   "guida": "cname.vercel-dns.com", // noCF
   "guide.guildedbot": "cname.vercel-dns.com", // noCF
-  "guide.guildedts": "cname.vercel-dns.com", // noCF
   "guild": "guild-js.github.io/guild.js",
   "guildcord": "guildcord.github.io/docs",
   "guilded": "cname.vercel-dns.com", // noCF
   "guildedapi": "rellylegend.github.io/guilded-api.js",
   "guildedbot": "guilded-bot-npm.github.io/Guilded-Bot-Docs",
-  "guildedts": "cname.vercel-dns.com", // noCF
   "guildeno": "guildeno.github.io/guildeno",
   "guildgate": "kavtuai.github.io/guildgate-docs",
   "guilds": "guildsjs.github.io/guilds.js",
@@ -1518,7 +1478,6 @@ var cnames_active = {
   "http4ts": "http4ts.github.io/http4ts",
   "httpfy": "devxprite.github.io/httpfy",
   "httpman": "httpman.github.io",
-  "httpunit": "samzh72.github.io/httpunit",
   "hub": "yyued.github.io/hub.js",
   "hubble": "hubble.netlify.app",
   "hubo": "huvboo.github.io",
@@ -1552,7 +1511,6 @@ var cnames_active = {
   "ienumerable": "mbasso.github.io/ienumerable",
   "iffe": "iffe-team.github.io",
   "iflow": "unadlib.github.io/iflow",
-  "igecorp": "igecorp.github.io/ige-djs-website",
   "ignite": "ignitejscl.github.io",
   "iiimix": "iiimix.github.io/iiimixjsorg",
   "iio": "iioinc.github.io/iio.js", // noCF? (don´t add this in a new PR)
@@ -1560,7 +1518,6 @@ var cnames_active = {
   "imagecapture": "googlechrome.github.io/imagecapture-polyfill",
   "imagin": "ilrc.github.io/imagin",
   "imagine": "karimayachi.github.io/imagine",
-  "imap-mailbox": "vsdparibas.github.io/imap-mailbox-doc",
   "imask": "unmanner.github.io/imaskjs",
   "imbue": "ghosts.github.io/Imbue",
   "imcvampire": "cname.vercel-dns.com", // noCF
@@ -1628,7 +1585,6 @@ var cnames_active = {
   "islisp": "ta2gch.github.io/islisp.js.org",
   "isolated-function": "kikobeats.github.io/isolated-function",
   "istanbul": "istanbuljs.github.io",
-  "itemszop": "michaljaz.github.io/itemszop",
   "itsashis4u": "itsashis4u.github.io", // noCF? (don´t add this in a new PR)
   "itunes-bridge": "angrykiller.github.io/iTunes-bridge",
   "itzik": "itzik.netlify.app",
@@ -1721,7 +1677,6 @@ var cnames_active = {
   "jsx2html": "maddouri.github.io/jsx2html",
   "jsxcad": "jsxcad.github.io",
   "juancarlosqr": "juancarlosqr.github.io", // noCF? (don´t add this in a new PR)
-  "julianflancheros": "julianflancheros.github.io/Prueba",
   "july": "onlyjuly.github.io",
   "juno-106": "stevengoldberg.github.io/juno-106", // noCF? (don´t add this in a new PR)
   "just": "js-just.github.io", // noCF
@@ -1746,7 +1701,6 @@ var cnames_active = {
   "karl": "focused-bassi-cc0eff.netlify.app",
   "karolina-and-ryan": "mockturtlesoup.github.io/karolina-and-ryan",
   "kasfy": "kasfy.github.io/kasfy.js.org",
-  "kasumi": "cname.vercel-dns.com", // noCF
   "katheesh": "katheesh.github.io/katheesh.js",
   "kavo": "kavo-labs.github.io/kavo",
   "kawaii": "moemoesoft.github.io/kawaii", // noCF
@@ -1763,14 +1717,12 @@ var cnames_active = {
   "kickstack": "cname.vercel-dns.com", // noCF
   "kilobyte": "kilobytehq.github.io/open-js",
   "kilvin": "rofrischmann.github.io/kilvin",
-  "kim": "khareemnurulla.github.io/kim",
   "kimera": "ultirequiem.github.io/kimera",
   "kindavishal": "kindavishal.netlify.app",
   "kiranremmarasu": "kiranremmarasu.github.io/kiranremmarasu",
   "kiss": "sisyphuszheng.github.io/kiss",
   "kite": "kite-js.github.io/kite",
   "kiwidocs": "arguiot.github.io/KiwiDocs",
-  "kkapi": "cname.vercel-dns.com", // noCF
   "kkna": "importantimport.github.io/kkna",
   "klasa": "dirigeants.github.io/klasa-website",
   "klayr-did": "aldhosutra.github.io/klayr-did",
@@ -1798,7 +1750,6 @@ var cnames_active = {
   "konsumer": "konsumer.github.io", // noCF? (don´t add this in a new PR)
   "koolclash": "sukkaw.github.io/Koolshare-Clash",
   "koot": "cmux.github.io/koot",
-  "koreanseal": "cname.vercel-dns.com", // noCF
   "koshi": "koshi-kvl.pages.dev", // noCF
   "kotori": "biyuehu.github.io/kotori-bot",
   "koutla-swiss": "leny.github.io/koutla-swiss",
@@ -1825,7 +1776,6 @@ var cnames_active = {
   "lad": "ladjs.github.io/lad",
   "lambda": "lambdajs.github.io", // noCF? (don´t add this in a new PR)
   "lan": "careteenl.github.io/lan",
-  "lance": "lancepioch.com",
   "landrielportafolio": "arielandriel30.github.io/landrielportafolio",
   "landroid": "lll69.github.io/landroid-web",
   "lang": "iso-639.github.io/language-code",
@@ -1910,7 +1860,6 @@ var cnames_active = {
   "lipsum": "llxlr.github.io/lipsum.js",
   "liquid-ajax-cart": "evgeniymukhamedjanov.github.io/liquid-ajax-cart",
   "liquivelte": "liquivelte.github.io/docs",
-  "listenin": "cname.vercel-dns.com", // noCF
   "lister": "jpbulman.github.io/lister",
   "listore": "yieldray.github.io/listore",
   "lite-web-server": "chasyumen.github.io/lite-web-server",
@@ -1962,7 +1911,6 @@ var cnames_active = {
   "lucy": "lucy-bot.github.io",
   "lukemetoki": "luke2m.github.io",
   "lume.shiraha": "importantimport.github.io/lume_theme_shiraha", // noCF
-  "lumi": "furioustsunami.github.io/lumijs",
   "lumpia": "lumpiajs.netlify.app",
   "lunisolar": "waterbeside.github.io/lunisolar-docs",
   "lunox": "kodepandai.github.io/lunox",
@@ -2095,7 +2043,6 @@ var cnames_active = {
   "merkletree": "miguelmota.github.io/merkletreejs",
   "merkur": "mjancarik.github.io/merkur",
   "mern": "iammohaiminul.github.io/MERNjs",
-  "mert": "mert574.github.io",
   "mesh": "crcn.github.io/mesh.js.org", // noCF? (don´t add this in a new PR)
   "meshesha": "meshesha.github.io",
   "metadata": "oknosoft.github.io/metadata.js",
@@ -2133,7 +2080,6 @@ var cnames_active = {
   "minidrone": "mechazawa.github.io/minidrone-js",
   "minify": "minify-js.github.io",
   "minigfm": "vercel.cdn.yt-blog.top", // noCF
-  "minigrid": "henriquea.github.io/minigrid", // noCF? (don´t add this in a new PR)
   "minimizedb": "acarrr.github.io/minimizedb",
   "mininote": "htdt.github.io/mininote",
   "minirouter": "milio48.github.io/minirouter.js",
@@ -2159,7 +2105,6 @@ var cnames_active = {
   "mnmlcss": "barelyhuman.github.io/mnml.css",
   "mo": "mirmousaviii.github.io/mo",
   "mobbler": "megaemce.github.io/mobbler",
-  "mobi": "mobidots.github.io",
   "mobileconfiginstaller": "rohit-chouhan.github.io/mobile-config-installer",
   "mobx": "mobx-js-org.onrender.com", // noCF
   "mobx-bonsai": "mobx-bonsai.netlify.app",
@@ -2215,7 +2160,6 @@ var cnames_active = {
   "mosaic": "tilework.github.io/mosaic.js.org",
   "mostage": "mirmousaviii.github.io/mostage",
   "motion-live": "cname.vercel-dns.com", // noCF
-  "mp": "cncdn.github.io",
   "mp3tag": "eidoriantan.github.io/mp3tag.js",
   "mpe": "weareroli.github.io/mpejs", // noCF? (don´t add this in a new PR)
   "mrinjamul": "mrinjamul.github.io/mrinjamul.js.org",
@@ -2257,7 +2201,6 @@ var cnames_active = {
   "mzaini30": "mzaini30.github.io",
   "mzplayer": "prince3661.github.io/Mzplayer",
   "n": "cyb.github.io/n",
-  "nabin": "nabin6246.github.io",
   "nacl-check": "magnusmarx.github.io/NaCL",
   "naja": "naja-js.github.io/naja",
   "namaste": "namaste-duniya.github.io/js",
@@ -2277,10 +2220,8 @@ var cnames_active = {
   "nautil": "tangshuang.github.io/nautil",
   "nautilus": "ignigena.github.io/nautilus",
   "nave": "naveteam.github.io/nave",
-  "nb-scraper": "chakszzz.github.io/NB-Scraper",
   "nbabot": "eliotchignell.github.io/NBABot",
   "ncub8": "ncub8.github.io", // noCF? (don´t add this in a new PR)
-  "neaps": "neaps.github.io",
   "nearley": "kach.github.io/nearley",
   "necord": "necordjs.github.io/necord.org",
   "nectar": "cname.vercel-dns.com", // noCF
@@ -2292,8 +2233,6 @@ var cnames_active = {
   "nera": "seebaermichi.github.io/nera-website",
   "nestcord": "globalartinc.github.io/nestcord",
   "nested-error": "ultirequiem.github.io/nested_error",
-  "nestjs-toolkit": "globalartinc.github.io/nestjs-toolkit",
-  "neteasecloudmusicapi": "w4ctech.github.io/NeteaseCloudMusicApi",
   "neteasecloudmusicapienhanced": "neteasecloudmusicapienhanced.github.io/api-enhanced",
   "neurax-api": "configneurax.netlify.app",
   "neureact": "kasmirawijayathunga.github.io/neureact",
@@ -2302,7 +2241,6 @@ var cnames_active = {
   "newbyte": "newbytee.github.io/newbyte",
   "newcar": "newcar-docs.netlify.app",
   "newton": "caracal7.github.io/newton.js",
-  "newyear": "dndrbots.github.io/new_year_counter",
   "nexbase-core": "petrunov.github.io/nexbase-core",
   "next": "zeit.github.io/next-site",
   "next-admin": "cname.vercel-dns.com", // noCF
@@ -2387,7 +2325,6 @@ var cnames_active = {
   "npmgraph": "cname.vercel-dns.com", // noCF
   "npwa": "cname.vercel-dns.com", // noCF
   "nrgy": "mnasyrov.github.io/nrgy",
-  "nsp": "hanul.github.io/NSP", // noCF? (don´t add this in a new PR)
   "nsptiles": "imthenachoman.github.io/nSPTiles", // noCF? (don´t add this in a new PR)
   "nsw-coronavirus": "maxgherman.github.io/nsw-coronavirus",
   "nugu": "vietcode.github.io/nugu",
@@ -2420,7 +2357,6 @@ var cnames_active = {
   "of": "r37r0m0d3l.github.io/of",
   "officetohtml": "meshesha.github.io/officetohtml",
   "offreddit": "pantheonlbs.github.io/offreddit",
-  "oguz": "okb1100.github.io",
   "oh-vue-icons": "oh-vue-icons.netlify.app",
   "ohmy": "mountainwang.github.io/ohmy",
   "oib": "andreicek.github.io/oib.js",
@@ -2473,7 +2409,6 @@ var cnames_active = {
   "overtrack": "aidant.github.io/overtrack.js",
   "ovo": "ovojs.github.io/OvO",
   "oxi": "cname.vercel-dns.com", // noCF
-  "oxycors": "cname.vercel-dns.com", // noCF
   "oz": "openzagreb.github.io",
   "p2p": "nuzulul.github.io/p2p.js",
   "p2psc": "kognise.github.io/p2psc",
@@ -2548,9 +2483,7 @@ var cnames_active = {
   "persian-tools": "persian-tools.github.io/persian-tools",
   "personalkanban": "nishantpainter.github.io/personal-kanban",
   "perspective": "leopoldthecoder.github.io/Perspective",
-  "peter": "peterccpang.github.io",
   "pguth": "pguth.github.io",
-  "ph1p": "ph1p.github.io",
   "phaker": "phakerjs.github.io/phaker.js",
   "phantom": "eliasnau.github.io/phantomjs",
   "pharaoh": "pharaoh-js.github.io", // noCF? (don´t add this in a new PR)
@@ -2655,7 +2588,6 @@ var cnames_active = {
   "profilie": "profilie.github.io",
   "program-builder": "program-builder.netlify.app",
   "progressbars": "josephabbey.github.io/progressbars",
-  "projects-tracker": "iamdevlinph.github.io/projects-tracker",
   "promethium": "promethiumjs.github.io/docs", // noCF
   "promptshield": "promptshield-io.github.io/promptshield",
   "pronouns": "cname.vercel-dns.com", // noCF
@@ -2714,8 +2646,6 @@ var cnames_active = {
   "quickredis": "hosting.gitbook.io", // noCF
   "quickreplit": "lebyy.github.io/quick.replit",
   "quickshadow": "cname.vercel-dns.com", // noCF
-  "quickuptime": "lebyy.github.io/quickuptimedocs",
-  "quicli": "thecodeah.github.io/quicli",
   "quillstack": "quillstack.pages.dev",
   "quincy": "quincyx.github.io",
   "quiz-app": "odevlord.github.io/Quiz-App", // noCF? (don´t add this in a new PR)
@@ -2747,7 +2677,6 @@ var cnames_active = {
   "rayo": "getrayo.github.io/rayo.js",
   "rclone": "sntran.github.io/rclone.js",
   "rdf": "rdfjs.github.io", // noCF
-  "rdpmovy": "rdp-studio.github.io/rdpmovy.js",
   "react-alert-box": "noumanqamar450.github.io/react-alert-box",
   "react-atomic-ui": "react-atomic.github.io/react-atomic-ui",
   "react-autosuggest": "moroshko.github.io/react-autosuggest", // noCF? (don´t add this in a new PR)
@@ -2891,7 +2820,6 @@ var cnames_active = {
   "rest-client": "foxifyjs.github.io/rest-client",
   "restjs": "daviesgeek.github.io/restjs", // noCF? (don´t add this in a new PR)
   "restore-scroll": "restore-scroll.netlify.app",
-  "reststops": "thomasbrueggemann.github.io/reststops",
   "resume": "xaoxuu.github.io/resume.js.org",
   "resume-builder": "blopa.github.io/Resume-Builder",
   "resumebuilder": "resumebuilder-dracu.netlify.app",
@@ -2944,7 +2872,6 @@ var cnames_active = {
   "router5": "hosting.gitbook.com",
   "routescape": "axtk.github.io/routescape",
   "routex": "routex.netlify.app",
-  "rovel": "rovelstars.github.io",
   "rp": "rpocklin.github.io", // noCF? (don´t add this in a new PR)
   "rplayer": "davland7.github.io/rplayer",
   "rsa": "cname.vercel-dns.com", // noCF
@@ -2996,7 +2923,6 @@ var cnames_active = {
   "sandmine": "spreehertz.github.io/Sandmine.js",
   "saso": "huruji.github.io/saso",
   "sass": "medialize.github.io/playground.sass.js", // noCF? (don´t add this in a new PR)
-  "satori": "satorijs.github.io/docs",
   "saturon": "cname.vercel-dns.com", // noCF
   "satyamark": "cname.vercel-dns.com", // noCF
   "saulosantiago": "saulosilva.github.io", // noCF? (don´t add this in a new PR)
@@ -3032,7 +2958,6 @@ var cnames_active = {
   "sdk-design": "hueitan.github.io/javascript-sdk-design",
   "searchconfig": "tomchen.github.io/searchconfig",
   "season": "seasonjs.github.io/tools",
-  "seatbelt": "seatbeltjs.github.io/seatbelt",
   "seatchart": "omarmahili.github.io/seatchart.js",
   "sebasvalcar": "sebasvalcar.github.io/portafolio",
   "secrethitler": "finncowbell.github.io/DetectiveDictator",
@@ -3047,7 +2972,6 @@ var cnames_active = {
   "segno": "keimeno.github.io/segno",
   "segoe-mdl2-css": "ckgrafico.github.io/Segoe-mdl2-assets-css", // noCF? (don´t add this in a new PR)
   "seia": "importantimport.github.io/seia",
-  "select_io": "selaromi.github.io/select_io", // noCF? (don´t add this in a new PR)
   "selectable-grid": "pisyukaev.github.io/selectable-grid",
   "selectors": "selectors.github.io/selectors.js",
   "selectre": "alexeyraspopov.github.io/selectre",
@@ -3076,7 +3000,6 @@ var cnames_active = {
   "share": "jeff-tian.github.io/weshare",
   "sharec": "lamartire.github.io/sharec",
   "shareon": "shareon.kytta.codeberg.page", // noCF
-  "sharingan": "techmonowar.github.io/sharingan",
   "sheet": "sheetjs.github.io/sheet.js.org",
   "shekhar": "shekharreddy4.github.io/Shekhar",
   "shell": "adaltas.github.io/node-shell",
@@ -3135,7 +3058,6 @@ var cnames_active = {
   "sirkit": "seckwei.github.io/SirKit_CircuitSim", // noCF? (don´t add this in a new PR)
   "sissi": "sissijs.github.io/sissi",
   "sitelo": "paul-browne.github.io/sitelo",
-  "sizle": "christoga.github.io/sizle", // noCF? (don´t add this in a new PR)
   "sjpm": "toggledtech.github.io/SJPM",
   "sjy": "cname.vercel-dns.com", // noCF
   "skeld": "skeldjs.github.io/SkeldJS",
@@ -3147,7 +3069,6 @@ var cnames_active = {
   "skratch": "websyncs.github.io/skratch",
   "sksamim": "esksamim.github.io/sksamim",
   "skyle": "skylejs.github.io/skyle",
-  "skyscript": "cname.vercel-dns.com", // noCF
   "skyware": "skyware-js.github.io/web", // noCF
   "slang": "ramadis.github.io/slang", // noCF? (don´t add this in a new PR)
   "slapshot": "dvhsh.github.io/slapshot.ts",
@@ -3159,10 +3080,8 @@ var cnames_active = {
   "slides": "deadcoder0904.github.io/slides-official-website",
   "slidey": "thegreatrazz.github.io/slidey",
   "slim": "eavichay.github.io/slim.js",
-  "slimetype": "slimewell.github.io/slimetype",
   "slinky": "alizahid.github.io/slinky",
   "slyde": "tygo-van-den-hurk.github.io/Slyde",
-  "smartestchatbot": "lebyy.github.io/smartestchatbotdocs",
   "smartquotes": "kellym.github.io/smartquotes.js",
   "smiley": "smiley422.github.io",
   "smoke": "hxgf.github.io/smoke",
@@ -3171,7 +3090,6 @@ var cnames_active = {
   "snail-ide": "snail-ide.github.io",
   "snake": "pakastin.github.io/snake",
   "snaplabs": "cname.vercel-dns.com", // noCF
-  "snapshot": "vishnupsatish.github.io/snapshot",
   "snekfetch": "devsnek.github.io/snekfetch",
   "snip": "ashy-sea-0a4231910.5.azurestaticapps.net", // noCF
   "snipify": "cname.vercel-dns.com", // noCF
@@ -3185,7 +3103,6 @@ var cnames_active = {
   "sociably": "machinat.github.io/sociably",
   "social-likes": "sapegin.github.io/social-likes", // noCF? (don´t add this in a new PR)
   "social-likes-next": "sapegin.github.io/social-likes-next", // noCF? (don´t add this in a new PR)
-  "social-sdk": "socialmated.github.io/social-sdk",
   "soda": "yieldray.github.io/soda",
   "solace": "cname.vercel-dns.com", // noCF
   "solara": "getsolarajs.github.io/solara-docs",
@@ -3380,7 +3297,6 @@ var cnames_active = {
   "syr": "dmikey.github.io/syr",
   "system-monitoring": "miladezzat.github.io/system-monitoring",
   "t": "l-js.mydevapp.tfuture.eu.org", // noCF
-  "t8": "t8js.github.io",
   "tab": "gdmcc.github.io/tab",
   "tabs": "mehrizi.github.io/tabs",
   "tagscript": "cname.vercel-dns.com", // noCF
@@ -3423,7 +3339,6 @@ var cnames_active = {
   "teletype": "keyvank.github.io/teletype.js",
   "temme": "shinima.github.io/temme",
   "template-pro": "template-pro.github.io",
-  "templates.linksharer": "linksharer.github.io/Templates", // noCF
   "temporal-fns": "rhnorskov.github.io/temporal-fns",
   "tenrai": "cname.vercel-dns.com", // noCF
   "tenvoy": "togatech.github.io/tEnvoy",
@@ -3547,7 +3462,6 @@ var cnames_active = {
   "turbo": "turbo.github.io",
   "turboforge": "turboforge-dev.github.io/turboforge",
   "turboprisma": "cname.vercel-dns.com", // noCF
-  "tusk": "cname.vercel-dns.com", // noCF
   "tw-themes": "kevinast.github.io/tw-themes",
   "twallpaper": "crashmax-dev.github.io/twallpaper",
   "twcopy": "the94air.github.io/twcopy",
@@ -3574,7 +3488,6 @@ var cnames_active = {
   "typewriter": "nicesapien.github.io/typewriter.js",
   "tyshemo": "tangshuang.github.io/tyshemo",
   "tyvn": "milo123459.github.io/tyvn",
-  "u": "hanul.github.io/UJS", // noCF? (don´t add this in a new PR)
   "uav": "unearth-inc.github.io/uav",
   "ubereats": "korobaka.github.io/ubereats.js",
   "udnisap": "udnisap.github.io",
@@ -3613,7 +3526,6 @@ var cnames_active = {
   "unsafe": "unsafely.github.io/unsafe.js",
   "unuse": "un-ts.github.io/unuse",
   "up": "codefeathers.github.io/up",
-  "updates.flightpkg": "cname.vercel-dns.com", // noCF
   "updevs-db": "up-devs.github.io/db-docs",
   "uplo": "jpalumickas.github.io/uplo",
   "upload-smith": "cname.vercel-dns.com", // noCF
@@ -3628,7 +3540,6 @@ var cnames_active = {
   "use-bootstrap-select": "use-bootstrap.github.io/use-bootstrap-select",
   "use-bootstrap-tag": "use-bootstrap.github.io/use-bootstrap-tag",
   "use-bootstrap-toaster": "use-bootstrap.github.io/use-bootstrap-toaster",
-  "use-cookie-consent": "use-cookie-consent.github.io/use-cookie-consent-docs",
   "use-git": "teneplaysofficial.github.io/use-git",
   "use-github": "ultirequiem.github.io/use-github",
   "usedapp": "crypto-meta.github.io/usedapp.js.org",
@@ -3735,7 +3646,6 @@ var cnames_active = {
   "voloshins": "voloshins.github.io", // noCF? (don´t add this in a new PR)
   "vona": "vonajs.github.io/vona",
   "vorpal": "dthree.github.io/vorpal", // noCF? (don´t add this in a new PR)
-  "vortex": "puntillol59.github.io/vortex",
   "voxelcss": "jhwohlgemuth.github.io/voxelcss",
   "vpt": "sep2.github.io/vite-plugin-taro",
   "vscode-apielements": "xvincentx.github.io/vscode-apielements",
@@ -3766,7 +3676,6 @@ var cnames_active = {
   "vue-svg-loader": "vue-svg-loader.netlify.app",
   "vue-tiny-validate": "vue-tiny-validate.netlify.app",
   "vue-treeselect": "riophae.github.io/vue-treeselect",
-  "vue-utterances": "glitch.edgeapp.net",
   "vuejsindy": "vuejsindy.github.io",
   "vuelidate": "vuelidate.netlify.app",
   "vuelog": "myst729.github.io/Vuelog",
@@ -3896,7 +3805,6 @@ var cnames_active = {
   "xtype": "lucono.github.io/xtypejs", // noCF? (don´t add this in a new PR)
   "y2j": "ultirequiem.github.io/y2j",
   "y86": "quietshu.github.io/y86", // noCF? (don´t add this in a new PR)
-  "yadl": "yadljs.github.io",
   "yagolopez": "yagolopez.github.io",
   "yak": "cname.vercel-dns.com", // noCF
   "yaka": "cname.vercel-dns.com", // noCF
@@ -3920,14 +3828,12 @@ var cnames_active = {
   "yt-quota-manager": "arnav-kr.github.io/yt-quota-manager",
   "yu": "yuxizhe.github.io/yu",
   "yuko": "notmarx.github.io/Yuko-Website",
-  "yunite": "discify.github.io/yunite.js",
   "yup-phone": "abhisekp.github.io/yup-phone",
   "yurba": "cname.vercel-dns.com", // noCF
   "yurd": "thebigbot0000.github.io/yurd.js.org",
   "yuuka": "yuukajs.github.io/docs",
   "yuye": "cyea.github.io",
   "yvm": "tophat.github.io/yvm",
-  "zaimu": "zaimu.netlify.app", // noCF
   "zaporizhzhia": "zaporizhzhiajs.github.io",
   "zare": "ismailbinmujeeb.github.io/zare",
   "zed": "paul-browne.github.io/Zed-framework",


### PR DESCRIPTION
# JS.ORG CLEANUP

This pull request updates the cnames_active.js file following the [js.org cleanup](https://github.com/js-org/js.org/issues/12043).
This closes #12043.

The following entries are removed in this pull request as they were not claimed in the [cleanup issue](https://github.com/js-org/js.org/issues/12043):

 - [baicai.js.org](http://baicai.js.org)
 - [browse4extact.js.org](http://browse4extact.js.org)
 - [flavor.js.org](http://flavor.js.org)
 - [quicli.js.org](http://quicli.js.org)
 - [rovel.js.org](http://rovel.js.org)
 - [sizle.js.org](http://sizle.js.org)
 - [skyscript.js.org](http://skyscript.js.org)
 - [slimetype.js.org](http://slimetype.js.org)
 - [yunite.js.org](http://yunite.js.org)
 - [afmsavage.js.org](http://afmsavage.js.org)
 - [angular2in1.js.org](http://angular2in1.js.org)
 - [bachors.js.org](http://bachors.js.org)
 - [chig.js.org](http://chig.js.org)
 - [crawlx.js.org](http://crawlx.js.org)
 - [er-api-sdk.js.org](http://er-api-sdk.js.org)
 - [gitcrate.js.org](http://gitcrate.js.org)
 - [julianflancheros.js.org](http://julianflancheros.js.org)
 - [lumi.js.org](http://lumi.js.org)
 - [nabin.js.org](http://nabin.js.org)
 - [nestjs-toolkit.js.org](http://nestjs-toolkit.js.org)
 - [satori.js.org](http://satori.js.org)
 - [select_io.js.org](http://select_io.js.org)
 - [templates.linksharer.js.org](http://templates.linksharer.js.org)
 - [abcdb.js.org](http://abcdb.js.org)
 - [acarsy.js.org](http://acarsy.js.org)
 - [acker.js.org](http://acker.js.org)
 - [angular-uikit.js.org](http://angular-uikit.js.org)
 - [asdivyansh.js.org](http://asdivyansh.js.org)
 - [assay.js.org](http://assay.js.org)
 - [avg.js.org](http://avg.js.org)
 - [awardify.js.org](http://awardify.js.org)
 - [azbuka-vkusa.js.org](http://azbuka-vkusa.js.org)
 - [builders.js.org](http://builders.js.org)
 - [caicai.js.org](http://caicai.js.org)
 - [calisto.js.org](http://calisto.js.org)
 - [castyte.js.org](http://castyte.js.org)
 - [cats.js.org](http://cats.js.org)
 - [christo.js.org](http://christo.js.org)
 - [cite.js.org](http://cite.js.org)
 - [clevercord.js.org](http://clevercord.js.org)
 - [codeberry.js.org](http://codeberry.js.org)
 - [cqrs.js.org](http://cqrs.js.org)
 - [discord-gamecord.js.org](http://discord-gamecord.js.org)
 - [erin.js.org](http://erin.js.org)
 - [es6-module-seed.js.org](http://es6-module-seed.js.org)
 - [exeform.js.org](http://exeform.js.org)
 - [fakeyou.js.org](http://fakeyou.js.org)
 - [fan.js.org](http://fan.js.org)
 - [front-end.js.org](http://front-end.js.org)
 - [fw.js.org](http://fw.js.org)
 - [glitterbot.js.org](http://glitterbot.js.org)
 - [guide.guildedts.js.org](http://guide.guildedts.js.org)
 - [guildedts.js.org](http://guildedts.js.org)
 - [httpunit.js.org](http://httpunit.js.org)
 - [igecorp.js.org](http://igecorp.js.org)
 - [imap-mailbox.js.org](http://imap-mailbox.js.org)
 - [itemszop.js.org](http://itemszop.js.org)
 - [kasumi.js.org](http://kasumi.js.org)
 - [kim.js.org](http://kim.js.org)
 - [kkapi.js.org](http://kkapi.js.org)
 - [koreanseal.js.org](http://koreanseal.js.org)
 - [lance.js.org](http://lance.js.org)
 - [listenin.js.org](http://listenin.js.org)
 - [mert.js.org](http://mert.js.org)
 - [minigrid.js.org](http://minigrid.js.org)
 - [mobi.js.org](http://mobi.js.org)
 - [mp.js.org](http://mp.js.org)
 - [nb-scraper.js.org](http://nb-scraper.js.org)
 - [neaps.js.org](http://neaps.js.org)
 - [neteasecloudmusicapi.js.org](http://neteasecloudmusicapi.js.org)
 - [newyear.js.org](http://newyear.js.org)
 - [nsp.js.org](http://nsp.js.org)
 - [oguz.js.org](http://oguz.js.org)
 - [oxycors.js.org](http://oxycors.js.org)
 - [peter.js.org](http://peter.js.org)
 - [ph1p.js.org](http://ph1p.js.org)
 - [projects-tracker.js.org](http://projects-tracker.js.org)
 - [quickuptime.js.org](http://quickuptime.js.org)
 - [rdpmovy.js.org](http://rdpmovy.js.org)
 - [reststops.js.org](http://reststops.js.org)
 - [seatbelt.js.org](http://seatbelt.js.org)
 - [sharingan.js.org](http://sharingan.js.org)
 - [smartestchatbot.js.org](http://smartestchatbot.js.org)
 - [snapshot.js.org](http://snapshot.js.org)
 - [social-sdk.js.org](http://social-sdk.js.org)
 - [t8.js.org](http://t8.js.org)
 - [tusk.js.org](http://tusk.js.org)
 - [u.js.org](http://u.js.org)
 - [updates.flightpkg.js.org](http://updates.flightpkg.js.org)
 - [use-cookie-consent.js.org](http://use-cookie-consent.js.org)
 - [vortex.js.org](http://vortex.js.org)
 - [vue-utterances.js.org](http://vue-utterances.js.org)
 - [yadl.js.org](http://yadl.js.org)
 - [zaimu.js.org](http://zaimu.js.org)

The following entries were listed in the [cleanup issue](https://github.com/js-org/js.org/issues/12043) but are now working, so are not being removed:

 - [taha.js.org](http://taha.js.org)
 - [idmp.js.org](http://idmp.js.org)
 - [dogstack.js.org](http://dogstack.js.org)
 - [request.js.org](http://request.js.org)

<!--

Required PR template for CI:

- [x] There is reasonable content on the page (see: [No Content](https://github.com/js-org/js.org/wiki/No-Content))
- [x] I have read and accepted the [Terms and Conditions](http://js.org/terms.html)
- The site content can be seen at https://*.js.org

> The site content is being removed by automation and is relevant to JavaScript developers specifically because they are existing JS.org subdomains that are abandoned.

-->


_:robot: Beep boop. I am a robot and performed this action automatically as part of the js.org cleanup process. If you have an issue, please contact the [js.org maintainers](https://github.com/js-org/js.org/issues/new)._
