### PR TITLE
Add broken-movies.js.org subdomain

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -434,6 +434,7 @@ var cnames_active = {
   "bright": "bright-js.github.io",
   "brigsby": "tynatsuhara.github.io/brigsby",
   "brizusan": "blackmyab.github.io/brizusan",
+  "broken-movies": "Neaterry6.github.io/BROKEN-Movies",
   "brotat": "mariobob.github.io/brotat-website",
   "browser-ocr": "oshekharo.github.io/Browser-OCR",
   "browserless": "microlinkhq.github.io/browserless",


### PR DESCRIPTION
Adding `broken-movies.js.org` for the BROKEN-Movies project page at https://neaterry6.github.io/BROKEN-Movies/

- Owner: Neaterry6
- Repo: BROKEN-Movies
- CNAME file already added to repo
- Custom domain already configured on GitHub Pages